### PR TITLE
Add install link and optional Marketplace/Open VSX publishing

### DIFF
--- a/.claude/skills/implement-cloudflare-hono/SKILL.md
+++ b/.claude/skills/implement-cloudflare-hono/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: implement-cloudflare-hono
+description: Turn a Canopy app spec (`.tsp` / `.arazzo`) into a best-practices app on the Canopy house stack — Hono + Zod + jose/OIDC on Cloudflare Workers (dual Node runtime), with the adapter/connector pattern and a slim core + plugins. Use when the user wants to implement, scaffold, or wire up endpoints/an app from the model spec ("implement this spec", "build the API for these entities", "wire up the Episode endpoints"). Input is the spec; pair with `model-spec`, which produces it.
+---
+
+# Implement a spec on the Cloudflare + Hono stack
+
+You turn an app **spec** (entities/endpoints/flows, produced by the `model-spec` skill) into running
+code on the Canopy house stack. The spec is the contract; you generate the implementation that
+satisfies it — and you keep it best-practices for *this* stack, not generic.
+
+This is one of potentially several `implement-*` skills. It owns exactly one target: Cloudflare
+Workers + Hono. The spec stays stack-agnostic; the opinions live here.
+
+## Step 0 — Read the contract first
+
+Before writing code, read:
+
+- `.claude/skills/implement-cloudflare-hono/stack.md` — the stack conventions + spec→code mapping.
+  **Read it every time.**
+- The spec you're implementing: `apps/api/spec/*.tsp` (+ any `.arazzo`). This is the source of truth
+  for *what* to build.
+- The existing app for the patterns to match — don't reinvent: `apps/api/src/app.ts` (Hono wiring),
+  `apps/api/src/worker-cf.ts` + `node.ts` (dual runtime entrypoints), `apps/api/src/auth/` (jose/OIDC),
+  and the relevant `@canopy/connector-*` / `@canopy/core` / `@canopy/store` packages.
+
+Match the real shapes. If a pattern exists in the codebase, follow it rather than introducing a new one.
+
+## Step 1 — Map the spec to the stack
+
+Work entity-first, the same order the spec is anchored. For each piece, see `stack.md` for the
+concrete pattern. In short:
+
+| Spec | Becomes |
+|---|---|
+| Entity (`@key` model) | a Zod schema + a store/adapter type; persistence via `@canopy/store` |
+| Endpoint (`interface` op) | a Hono route, validated with Zod, returning the spec's DTO shape |
+| Auth on an op | jose-verified bearer / OIDC middleware; ownership scoping |
+| DTO `model` | a Zod schema for the request/response body |
+| Flow (Arazzo) | the ordering/guards across the endpoints it sequences |
+
+Generate the routes to **honour the spec's `operationId`s** — they're the join between layers and the
+emitted OpenAPI. Don't drift names.
+
+## Step 2 — Hold the line on house style
+
+These are non-negotiable for this stack (detail in `stack.md`):
+
+- **Dual runtime** — code runs on both Workers (`worker-cf.ts`) and Node (`node.ts`); don't reach for
+  Node-only or CF-only APIs in shared code. Put runtime-specific bits behind the existing seams.
+- **Adapters over direct deps** — storage, connectors, and external services go through
+  `@canopy/store` / `@canopy/connector-*` interfaces, not inline SDK calls. Slim core, capability via
+  plugins.
+- **Validate at the boundary** — Zod on every request body/query; trust internal calls.
+- **OIDC, not bespoke auth** — bearer verification through the existing `auth/` + jose; never hand-roll
+  token logic.
+- **Keep latest deps** — match the versions already in `apps/api/package.json` (Hono 4, Zod 4, jose 6).
+
+## Step 3 — Verify before claiming done
+
+Run the real checks and report honestly (don't declare success on an unrun build):
+
+- the spec still compiles and the OpenAPI emits (`@typespec/openapi3` is wired in `apps/api`)
+- `tsc` typechecks the new code
+- routes match the spec's `operationId`s and DTO shapes
+- new external dependencies go through an adapter, not a direct import
+
+If something doesn't pass, say so with the output. If a step was skipped, say that.
+
+## Don't
+
+- Don't generate generic Express/Node boilerplate — this stack is Hono on Workers.
+- Don't add features, tables, or endpoints the spec doesn't call for. Implement the contract; the spec
+  is where scope changes happen (hand back to `model-spec`).
+- Don't bypass the adapters to "just call the SDK" — that's the thing this stack exists to avoid.

--- a/.claude/skills/implement-cloudflare-hono/stack.md
+++ b/.claude/skills/implement-cloudflare-hono/stack.md
@@ -1,0 +1,73 @@
+# Cloudflare + Hono stack conventions
+
+The Canopy house stack for the API worker. Read this with the actual code in `apps/api/src/` open —
+this doc is the map; the code is the territory.
+
+## The stack
+
+| Concern | Choice | Where |
+|---|---|---|
+| HTTP framework | **Hono 4** | `apps/api/src/app.ts` builds the app; route groups mounted there |
+| Validation | **Zod 4** | request bodies/queries; schemas mirror the spec's DTO `model`s |
+| Auth | **jose 6 + OIDC** (authhero-style) | `apps/api/src/auth/`; bearer verification, not bespoke |
+| Runtime | **Cloudflare Workers** primary, **Node** parallel | `worker-cf.ts` (CF) + `node.ts` (Node) entrypoints |
+| Contract | **TypeSpec** → OpenAPI 3 | `apps/api/spec/`; `@typespec/openapi3` emits the doc |
+| Persistence / IO | **adapters** | `@canopy/store`, `@canopy/connector-*`, `@canopy/core` (workspace deps) |
+| MCP / containers | as wired | `src/mcp/`, `src/container/` — follow existing patterns |
+
+Slim core, capability via plugins/connectors. Cloudflare-first, but never CF-only in shared code.
+
+## Spec → code mapping (the patterns)
+
+### Entity → schema + store
+A `@key` entity becomes:
+1. a **Zod schema** (`EpisodeSchema`) — the validated shape, source of the TS type via `z.infer`.
+2. persistence through **`@canopy/store`** — don't open a DB client inline. The store/adapter
+   interface is the seam; a Workers deployment binds D1/R2, a Node deployment binds its own driver,
+   and the route code doesn't know the difference.
+
+Don't define a hand-written `interface Episode {…}` next to the Zod schema — infer it.
+
+### Endpoint → Hono route
+Each spec op (`interface` method with `@operationId`) becomes one Hono handler:
+- mount under the spec's `@route`, with the matching HTTP verb;
+- validate `@body`/`@query` with the Zod DTO schema (`zValidator` or explicit `.parse`);
+- return the spec's response DTO; map errors to the spec's `Thing | Error` union and status codes
+  (201 for create with `@statusCode`, etc.);
+- name the handler/route so it's traceable to the `operationId` — that id is the contract join and
+  shows up in the emitted OpenAPI.
+
+Group routes by resource into a Hono sub-app and mount it in `app.ts`, the way existing groups are.
+
+### Auth → middleware
+Default every route to bearer auth via the existing `auth/` helpers (jose verification of the OIDC
+token). Only the ops the spec marks `@useAuth(NoAuth)` skip it. Scope mutations to the
+owner/member — read the principal from the verified token, don't trust a body field.
+
+### Flow (Arazzo) → orchestration
+A flow constrains *ordering and guards* across endpoints (e.g. can't `publishEpisode` before
+`createEpisode`; emit `EpisodePublished` after). Implement those as guards/sequencing in the handlers
+or a small orchestration helper — the flow doesn't add new endpoints, it sequences existing ones.
+
+## Dual-runtime rules
+
+- Shared code (routes, services, schemas) must run on **both** Workers and Node. No `node:fs`, no
+  CF-only globals in shared modules.
+- Runtime-specific wiring lives at the entrypoints: `worker-cf.ts` (bindings, DO/R2/D1) and `node.ts`
+  (`@hono/node-server`). New runtime-specific needs go behind an adapter, surfaced at the entrypoint —
+  not branched inline in a handler.
+
+## Adapter discipline
+
+Anything that talks to the outside — storage, a NAS/repo connector, an external API — goes through an
+interface in `@canopy/store` / `@canopy/connector-*`, not a direct SDK import in the worker. This is
+the core reason the same app runs on Workers and Node and against R2/local/Synology/GitHub. If a new
+integration is needed, add or extend a connector; don't inline it.
+
+## Verify
+
+- `apps/api` spec compiles + OpenAPI emits (TypeSpec compiler + `@typespec/openapi3` are devDeps).
+- `tsc` clean on new code.
+- routes ↔ spec `operationId`s and DTO shapes line up (diff against the emitted OpenAPI if unsure).
+- no direct external SDK import that should be an adapter.
+- versions match `apps/api/package.json` — don't pin older Hono/Zod/jose.

--- a/.claude/skills/model-spec/SKILL.md
+++ b/.claude/skills/model-spec/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: model-spec
+description: Design and edit the Canopy app model — entities, endpoints, events, and flows — as the spec files the model-editor renders (`.tsp` / `.arazzo` / `.prisma`). Stack-agnostic: produces the contract, not the implementation. Use when the user wants to model a domain or app ("model a podcast app", "add a Subscription entity", "design the publish flow", "what endpoints does Episode need"). Pair with an `implement-*` skill to turn the spec into a running app.
+---
+
+# Model a Canopy app spec
+
+You design and edit the **app spec** — the source-of-truth files the model-editor renders on its
+canvas. The spec is stack-agnostic: it says *what* the app is, never *how* it's built. A separate
+`implement-*` skill turns this spec into a running app for one stack.
+
+The files ARE the interface. You edit text; the canvas reacts (the editor live-reloads on external
+change). You never need a canvas API.
+
+## Step 0 — Read the contract first
+
+Before editing, read these so you match the real shapes:
+
+- `.claude/skills/model-spec/conventions.md` — the layered AppSpec vocabulary + best-practices
+  conventions (this is the source of truth for *good* modelling). **Read it every time.**
+- `apps/api/spec/main.tsp` + `apps/api/spec/models.tsp` — the canonical, hand-written example of a
+  well-formed spec. Match its idioms (`@route`, `@operationId`, `@useAuth`, `@key`, doc comments).
+- The file(s) you're about to edit. If none exist yet, create them next to where the app lives.
+
+Do not invent TypeSpec/Arazzo constructs. If it isn't in `conventions.md` or the example specs, check
+the official compiler before using it.
+
+## Step 1 — Establish scope, then act
+
+For a **new app** with a recognizable domain ("a podcast app"), do NOT interview — produce a complete
+first-draft model immediately, then ask what to refine. Only ask a clarifying question when the domain
+is genuinely ambiguous about *what* to build.
+
+For an **edit**, make the smallest change that satisfies the request, then check the layer is still
+consistent (see Step 3).
+
+## Step 2 — Work the layers (entities are the anchor)
+
+The model is one co-evolving spec across four layers. Edit any layer on any turn; they reference each
+other, so a change in one often implies a change in another. Always keep the layers consistent.
+
+| Layer | Lives in | Shape |
+|---|---|---|
+| **Entities** + relations | `models.tsp` (or `.prisma`) | TypeSpec `model` with a `@key`; refs between models |
+| **Endpoints** | `main.tsp` (or sibling `.tsp`) | `interface` with `@route` ops, each `@operationId` |
+| **Flows** | `*.arazzo.(yaml\|json)` | Arazzo workflow; steps reference ops by `operationId` |
+| **Events** | not yet represented | model the data + note "behaviour not yet in the spec" |
+
+Apply the conventions from `conventions.md` automatically — every entity gets a primary key and CRUD
+endpoints, list endpoints paginate, mutations with side effects imply an event, flows tie a user
+intent to endpoints. Don't make the user ask for the obvious supporting pieces; propose them.
+
+## Step 3 — Keep it buildable (completeness pass)
+
+After a change, scan for gaps — these are what turn a sketch into a spec, and they're the next round
+of work, not errors to hide:
+
+- entity with no endpoints; endpoint touching no entity
+- `operationId` referenced by a flow but not defined (and vice-versa)
+- relation pointing at a deleted/renamed model
+- an event with no producer or no subscriber (once events exist)
+
+The editor's `DiagnosticsBar` already flags dangling `operationId`s and deleted-model refs — surface
+anything it would, plus the coverage gaps above. State the gaps; offer to fill them.
+
+## Round-trip rules (don't lose work)
+
+- **`.tsp` / `.arazzo` are the source of truth** and round-trip cleanly. Prefer them.
+- **`.prisma` is lossy by default** — `uuid`/`text` collapse to `String`, `@default`/`@@`-attrs and
+  comments drop on the pure-Prisma path. If exact types/positions matter, the editor's "Embed
+  metadata" option writes a `// @canopy-model {json}` header for a lossless restore. Don't hand-strip
+  that header.
+- **Node positions/colors live in a `canopy.layout.json` sidecar**, not in the model files. Don't put
+  layout in the spec; let the canvas auto-layout, or edit the sidecar if asked.
+- Don't delete DTO `model`s (request/response payloads) thinking they're stray entities — they're the
+  typed operation contract. Entity vs DTO is: a model is an **entity** if it has `@key` or is reachable
+  from a `@key` model; everything else is a DTO.
+
+## Hand-off
+
+When the user wants this built, point them at the matching `implement-*` skill (e.g.
+`implement-cloudflare-hono`). The spec you produced is its input — you stay stack-agnostic.

--- a/.claude/skills/model-spec/conventions.md
+++ b/.claude/skills/model-spec/conventions.md
@@ -1,0 +1,79 @@
+# App-spec conventions — the "good modelling" rules
+
+You are a senior data modeller. Your job is to design a spec that a stack skill can turn into a
+**best-practices app** with no further decisions needed. The vocabulary below says what's *possible*;
+these conventions say what's *good*. Apply them by default — the user shouldn't have to ask for the
+obvious supporting pieces.
+
+## The layered AppSpec
+
+One co-evolving model, four layers, entities as the anchor (everything references them):
+
+```
+entities ──< endpoints ──< flows
+    └──────< events
+```
+
+You go back and forth between layers — adding an endpoint often implies a new entity field and an
+event; adding a flow implies the endpoints it sequences. Always return a consistent whole.
+
+### Entities (anchor layer)
+
+- Every entity has a **primary key** (`@key id: string` — uuid unless the domain dictates otherwise).
+- Name in singular PascalCase (`Episode`, not `episodes`).
+- Properties carry a real type; mark `required`/`unique` honestly. Use enums for fixed value sets.
+- Relations are explicit and directional (`1-1`, `1-N`, `N-1`, `N-M`) with a verb label
+  ("Podcast *has many* Episode"). A foreign key is a `ref` to the target entity.
+- A short doc comment per entity and per non-obvious property.
+
+### Endpoints
+
+- **Every entity gets CRUD** unless there's a reason not to: `list`, `get`, `create`, `update`,
+  `delete`. Name ops `listEpisodes`, `getEpisode`, etc., and give each a stable `@operationId`.
+- **List endpoints paginate** and support an obvious filter/sort where the domain implies one.
+- **Auth + ownership on every endpoint** — default to bearer auth (`@useAuth(BearerAuth)`); only the
+  few genuinely public ops use `NoAuth`. Scope mutations to the owner/member.
+- Request/response bodies are explicit DTO `model`s, not inline anonymous shapes — they're the typed
+  contract a stack skill generates from.
+- Mutations that have side effects (publishing, sending, charging) **imply an event** (below).
+
+### Events
+
+- Model an event when a state change matters to something other than the caller — `EpisodePublished`,
+  `SubscriptionCancelled`. An event has a name, the entity it concerns, and a payload.
+- Events aren't representable in the spec files *yet*. Until they are: model the data the event
+  carries (often a field on the entity, e.g. `publishedAt`) and **note in your reply** that the
+  behaviour (who emits, who subscribes) isn't captured in the spec. Don't silently drop it.
+
+### Flows
+
+- A flow ties a **user intent** to a sequence of endpoints (and events): "Creator publishes an
+  episode" → `createEpisode` → `publishEpisode` → `EpisodePublished`.
+- Flows live in Arazzo workflows; steps reference endpoints by `operationId`. Keep step ids stable.
+- Model a flow when the sequence is non-obvious or spans multiple entities — not for a bare CRUD call.
+
+## Draft-first for known domains
+
+When the user names a recognizable domain, produce a complete first draft in one turn — entities with
+keys and relations, CRUD endpoints, the one or two core flows — then ask what to refine. Don't
+interrogate before showing anything. "Make a podcast app" should yield `Podcast / Episode / Host /
+Subscriber / Category`, their relations, CRUD ops, and a publish flow, immediately.
+
+## Scope boundary
+
+You model the **app contract** — data, operations, flows. You do not write implementation code, choose
+a framework, or pick a database. If asked to build it, hand off to an `implement-*` skill. If asked for
+something the spec can't yet hold (events, auth policy detail, infra), model what you can and say
+plainly what isn't represented.
+
+## TypeSpec idioms (match `apps/api/spec/`)
+
+- `@service`, `@server`, namespace, `@useAuth(BearerAuth)` at the top; `@useAuth(NoAuth)` per public op.
+- `interface` per resource group; `@route("/api/...")` + `@get/@post/@patch/@delete` + `@operationId`.
+- `@key` marks an entity's identity. DTOs are plain `model`s with no `@key`, reachable only through ops.
+- Union return types for errors: `Thing | Error`. A 201-create returns `{ @statusCode statusCode: 201;
+  @body created: Thing }`.
+- `@tag(...)` / `@extension("x-tags", #[...])` group entities/ops/flows; the editor reads tags
+  read-only for its per-view filter — don't rely on writing them back.
+- DELETE-with-body isn't expressible in OpenAPI 3.0 — model those as `POST .../remove` (see how
+  `removeMember` is done in `main.tsp`).

--- a/.github/workflows/release-vscode-extension.yml
+++ b/.github/workflows/release-vscode-extension.yml
@@ -3,6 +3,11 @@ name: Release VS Code extension
 # Builds the Canopy Model Editor extension and publishes the .vsix.
 # - Push a tag like `vscode-model-editor-v0.0.1` → a GitHub Release with the .vsix attached.
 # - Run manually (workflow_dispatch) → the .vsix is uploaded as a build artifact only.
+#
+# Marketplace / Open VSX publishing is optional: it runs on a tag only when the
+# corresponding repository secret is set, and is skipped otherwise.
+#   - VSCE_PAT  → VS Code Marketplace (https://marketplace.visualstudio.com/manage)
+#   - OVSX_PAT  → Open VSX (https://open-vsx.org)
 on:
   push:
     tags:
@@ -18,6 +23,9 @@ jobs:
     defaults:
       run:
         working-directory: apps/vscode-model-editor
+    env:
+      VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      OVSX_PAT: ${{ secrets.OVSX_PAT }}
     steps:
       - uses: actions/checkout@v4
 
@@ -52,3 +60,11 @@ jobs:
         with:
           files: apps/vscode-model-editor/canopy-model-editor.vsix
           generate_release_notes: true
+
+      - name: Publish to VS Code Marketplace
+        if: startsWith(github.ref, 'refs/tags/') && env.VSCE_PAT != ''
+        run: pnpm exec vsce publish --no-dependencies --packagePath canopy-model-editor.vsix --pat "$VSCE_PAT"
+
+      - name: Publish to Open VSX
+        if: startsWith(github.ref, 'refs/tags/') && env.OVSX_PAT != ''
+        run: pnpm dlx ovsx publish canopy-model-editor.vsix --pat "$OVSX_PAT"

--- a/apps/model-editor-demo/README.md
+++ b/apps/model-editor-demo/README.md
@@ -1,0 +1,37 @@
+# Canopy Model Editor — Local Demo
+
+A standalone, backend-free web app that runs the **Canopy Model Editor** plugin
+(`@canopy/model-editor`) against a **real folder on your machine**. It's the
+simplest way to try the visual editors for Prisma schemas, TypeSpec APIs, Arazzo
+workflows and AsyncAPI channels without the portal or the VS Code extension.
+
+## How it works
+
+The Model Editor is a trusted plugin that talks to its host through a small
+`HostBridge` interface (read/write files, AI, etc.). This app implements that
+bridge over the browser's [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API):
+
+- [`src/fs-host-bridge.ts`](src/fs-host-bridge.ts) — the `HostBridge`, where file
+  ids are paths relative to the folder you grant access to.
+- [`src/main.tsx`](src/main.tsx) — folder picker, file sidebar, and the
+  `ModelEditorFileRouter` that dispatches each file to the right canvas.
+
+Edits save straight back to disk. No server, no build step on your files.
+
+## Run it
+
+```sh
+pnpm --filter @canopy/model-editor-demo dev
+```
+
+Open the printed URL, then either:
+
+- **Open folder** — pick a directory with `.prisma`, `.tsp`, `.arazzo` or `.asyncapi` files
+  (edits save back to disk), or
+- **Try a sample** — load an in-memory Pet Store schema, no folder needed (handy
+  for a quick look or to compare drag performance against a known-small graph).
+
+## Browser support
+
+The File System Access API is Chromium-only — use **Chrome, Edge or Arc**. The
+app shows a notice in browsers that don't support it.

--- a/apps/model-editor-demo/index.html
+++ b/apps/model-editor-demo/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Canopy Model Editor — Local Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/model-editor-demo/package.json
+++ b/apps/model-editor-demo/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@canopy/model-editor-demo",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Standalone browser demo of the Canopy Model Editor, running against a real local folder via the File System Access API.",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@canopy/model-editor": "workspace:*",
+    "@canopy/plugin-sdk": "workspace:*",
+    "@canopy/ui": "workspace:*"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.3.0",
+    "@types/react": "^19.2.15",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+    "tailwindcss": "^4.3.0",
+    "typescript": "~6.0.3",
+    "vite": "^8.0.13"
+  }
+}

--- a/apps/model-editor-demo/src/fs-host-bridge.ts
+++ b/apps/model-editor-demo/src/fs-host-bridge.ts
@@ -39,7 +39,19 @@ export function createFsHostBridge(
     },
     getFile: async (id) => {
       const { dir, name } = splitPath(id);
-      return { id, name, path: dir, kind: name.includes(".") ? undefined : "folder" };
+      try {
+        const parent = await dirHandle(root(), dir);
+        try {
+          await parent.getFileHandle(name);
+          return { id, name, path: dir };
+        } catch {
+          // Not a file — fall through to test for a directory of the same name.
+          await parent.getDirectoryHandle(name);
+          return { id, name, path: dir, kind: "folder" };
+        }
+      } catch {
+        return null; // no such entry (or its parent is gone)
+      }
     },
     listFiles: async (dir) => {
       const base = dir ?? "";

--- a/apps/model-editor-demo/src/fs-host-bridge.ts
+++ b/apps/model-editor-demo/src/fs-host-bridge.ts
@@ -1,0 +1,116 @@
+import type { AiModel, HostBridge, PluginFile } from "@canopy/plugin-sdk";
+
+/**
+ * A {@link HostBridge} backed by the browser's File System Access API. The user
+ * grants access to a real local folder once; from then on the Model Editor reads
+ * and writes the files on disk through this bridge, exactly as it would against the
+ * Canopy drive or the VS Code host.
+ *
+ * File ids are POSIX-style paths relative to the granted root folder (e.g.
+ * `schema.prisma` or `api/petstore.tsp`); the empty string is the root itself.
+ * Everything the Model Editor never touches (spaces, connectors, plugin settings,
+ * AI) is stubbed so the contract stays satisfied.
+ */
+export function createFsHostBridge(
+  getRoot: () => FileSystemDirectoryHandle | null,
+  openFile: (file: PluginFile) => void,
+): HostBridge {
+  const root = (): FileSystemDirectoryHandle => {
+    const handle = getRoot();
+    if (!handle) throw new Error("No folder opened yet");
+    return handle;
+  };
+
+  const unsupported = (name: string): never => {
+    throw new Error(`${name} is not available in the local filesystem demo`);
+  };
+
+  return {
+    online: true,
+    readFileText: async (id) => {
+      const file = await (await fileHandle(root(), id)).getFile();
+      return file.text();
+    },
+    saveFileVersion: async (id, text) => {
+      const handle = await fileHandle(root(), id);
+      const writable = await handle.createWritable();
+      await writable.write(text);
+      await writable.close();
+    },
+    getFile: async (id) => {
+      const { dir, name } = splitPath(id);
+      return { id, name, path: dir, kind: name.includes(".") ? undefined : "folder" };
+    },
+    listFiles: async (dir) => {
+      const base = dir ?? "";
+      const handle = await dirHandle(root(), base);
+      const out: PluginFile[] = [];
+      for await (const [name, entry] of handle.entries()) {
+        if (name.startsWith(".")) continue;
+        out.push({
+          id: base ? `${base}/${name}` : name,
+          name,
+          path: base,
+          kind: entry.kind === "directory" ? "folder" : undefined,
+        });
+      }
+      return out;
+    },
+    createFile: async (dir, name, content) => {
+      const base = dir ?? "";
+      const handle = await dirHandle(root(), base);
+      const fh = await handle.getFileHandle(name, { create: true });
+      const writable = await fh.createWritable();
+      await writable.write(content);
+      await writable.close();
+      return { id: base ? `${base}/${name}` : name, name, path: base };
+    },
+    createAndOpenFile: async ({ name, content }) => {
+      const fh = await root().getFileHandle(name, { create: true });
+      const writable = await fh.createWritable();
+      await writable.write(content);
+      await writable.close();
+      const file: PluginFile = { id: name, name, path: "" };
+      openFile(file);
+      return file;
+    },
+
+    // No AI provider in the static demo — the assistant simply offers no models.
+    aiGenerate: async () => unsupported("aiGenerate"),
+    listAiModels: async (): Promise<AiModel[]> => [],
+
+    // Not applicable in the editor-only filesystem demo:
+    getPluginSettings: async () => null,
+    savePluginSettings: async () => {},
+    getPluginPlaces: async () => [],
+    applySpacePlugin: async () => unsupported("applySpacePlugin"),
+    removeSpacePlugin: async () => unsupported("removeSpacePlugin"),
+    listSpaces: async () => [],
+    syncConnector: async () => ({ ok: false, error: "Connectors are not available in the demo" }),
+    testConnector: async () => ({ ok: false, error: "Connectors are not available in the demo" }),
+    listMount: async () => [],
+    readMountText: async () => unsupported("readMountText"),
+    mountFileUrl: () => "",
+  };
+}
+
+/** Split a relative file id into its containing directory and base name. */
+function splitPath(id: string): { dir: string; name: string } {
+  const i = id.lastIndexOf("/");
+  return i === -1 ? { dir: "", name: id } : { dir: id.slice(0, i), name: id.slice(i + 1) };
+}
+
+/** Walk from the root to the directory handle at a relative path (empty = root). */
+async function dirHandle(root: FileSystemDirectoryHandle, dir: string): Promise<FileSystemDirectoryHandle> {
+  let handle = root;
+  for (const segment of dir.split("/").filter(Boolean)) {
+    handle = await handle.getDirectoryHandle(segment);
+  }
+  return handle;
+}
+
+/** Resolve the file handle for a relative file id. */
+async function fileHandle(root: FileSystemDirectoryHandle, id: string): Promise<FileSystemFileHandle> {
+  const { dir, name } = splitPath(id);
+  return (await dirHandle(root, dir)).getFileHandle(name);
+}

--- a/apps/model-editor-demo/src/globals.d.ts
+++ b/apps/model-editor-demo/src/globals.d.ts
@@ -1,0 +1,13 @@
+// Side-effect CSS imports are resolved by Vite at build time; declare the module
+// so `tsc --noEmit` (which has no bundler ambient types) accepts them.
+declare module "*.css";
+
+// `showDirectoryPicker` is part of the File System Access API but isn't in the
+// standard DOM lib types yet. Declare just the slice the demo relies on.
+interface Window {
+  showDirectoryPicker(options?: {
+    id?: string;
+    mode?: "read" | "readwrite";
+    startIn?: "desktop" | "documents" | "downloads" | "music" | "pictures" | "videos";
+  }): Promise<FileSystemDirectoryHandle>;
+}

--- a/apps/model-editor-demo/src/index.css
+++ b/apps/model-editor-demo/src/index.css
@@ -1,0 +1,17 @@
+@import "tailwindcss";
+/* Shared Canopy palette, fonts, @theme mapping and dark variant. */
+@import "../../../packages/ui/src/tokens.css";
+
+/* The shared UI + model-editor classes live outside this app, so point Tailwind's
+   content scanner at their source to generate the utilities they use. */
+@source "../../../packages/ui/src";
+@source "../../../packages/model-editor/src";
+
+html,
+body,
+#root {
+  height: 100%;
+}
+body {
+  margin: 0;
+}

--- a/apps/model-editor-demo/src/main.tsx
+++ b/apps/model-editor-demo/src/main.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { PluginHostProvider } from "@canopy/plugin-sdk";
+import { ModelEditorFileRouter, SAMPLE_PROJECT, SAMPLE_ENTRYPOINT } from "@canopy/model-editor";
+import { Icon } from "@canopy/ui";
+import type { PluginFile } from "@canopy/plugin-sdk";
+import { createFsHostBridge } from "./fs-host-bridge";
+import { createSampleBridge } from "./sample-bridge";
+import "./index.css";
+
+/** The file kinds the Model Editor claims, used to populate the sidebar. */
+const SUPPORTED = /\.(prisma|tsp|(arazzo|asyncapi)(\.(ya?ml|json))?)$/i;
+
+type Entry = { id: string; name: string; dir: string };
+
+// The shared Pet Store sample, as sidebar entries (root-level, openable kinds only).
+// `openapi.yaml` is omitted here — it isn't directly openable but is still served by
+// the sample bridge so the spec editor discovers it as a sibling.
+const SAMPLE_ENTRIES: Entry[] = SAMPLE_PROJECT.filter((f) => SUPPORTED.test(f.name)).map((f) => ({
+  id: f.name,
+  name: f.name,
+  dir: "",
+}));
+
+/** Recursively collect supported model files under a folder, skipping noise. */
+async function walk(handle: FileSystemDirectoryHandle, dir = "", depth = 0): Promise<Entry[]> {
+  if (depth > 6) return [];
+  const out: Entry[] = [];
+  for await (const [name, entry] of handle.entries()) {
+    if (name.startsWith(".") || name === "node_modules") continue;
+    const path = dir ? `${dir}/${name}` : name;
+    if (entry.kind === "directory") {
+      out.push(...(await walk(entry, path, depth + 1)));
+    } else if (SUPPORTED.test(name)) {
+      out.push({ id: path, name, dir });
+    }
+  }
+  return out.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function App() {
+  const [root, setRoot] = useState<FileSystemDirectoryHandle | null>(null);
+  const [sample, setSample] = useState(false);
+  const [files, setFiles] = useState<Entry[]>([]);
+  const [open, setOpen] = useState<Entry | null>(null);
+  const [dark, setDark] = useState(() => window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false);
+  const [error, setError] = useState<string | null>(null);
+  // Kept in a ref so the (stable) bridge always sees the current root handle.
+  const rootRef = useRef<FileSystemDirectoryHandle | null>(null);
+  rootRef.current = root;
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", dark);
+  }, [dark]);
+
+  const openEntry = useCallback((file: PluginFile) => {
+    setOpen({ id: file.id, name: file.name, dir: file.path ?? "" });
+  }, []);
+
+  // One bridge instance for the app's lifetime; it reads the live root via the ref.
+  const fsBridge = useMemo(() => createFsHostBridge(() => rootRef.current, openEntry), [openEntry]);
+  const sampleBridge = useMemo(() => createSampleBridge(), []);
+  const bridge = sample ? sampleBridge : fsBridge;
+
+  const loadSample = useCallback(() => {
+    setRoot(null);
+    setFiles(SAMPLE_ENTRIES);
+    // Open the contract first — it drives every tab in the spec workspace.
+    setOpen(SAMPLE_ENTRIES.find((f) => f.name === SAMPLE_ENTRYPOINT) ?? SAMPLE_ENTRIES[0] ?? null);
+    setSample(true);
+  }, []);
+
+  const pickFolder = useCallback(async () => {
+    setError(null);
+    try {
+      const handle = await window.showDirectoryPicker({ id: "canopy-model-editor", mode: "readwrite" });
+      const found = await walk(handle);
+      setSample(false);
+      setRoot(handle);
+      setFiles(found);
+      setOpen(found[0] ?? null);
+    } catch (e) {
+      // The user dismissing the picker throws AbortError — not worth surfacing.
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      setError(e instanceof Error ? e.message : "Couldn't open that folder");
+    }
+  }, []);
+
+  const supported = typeof window !== "undefined" && "showDirectoryPicker" in window;
+  const active = root !== null || sample;
+
+  return (
+    <PluginHostProvider value={bridge}>
+      <div className="flex h-full flex-col bg-background text-foreground">
+        <header className="flex items-center gap-3 border-b px-4 py-2">
+          <Icon name="database" size={18} className="text-primary" />
+          <span className="text-sm font-medium">Canopy Model Editor</span>
+          <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">local demo</span>
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              onClick={pickFolder}
+              className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm hover:bg-accent"
+            >
+              <Icon name="folder" size={14} />
+              {root ? "Change folder" : "Open folder"}
+            </button>
+            <button
+              onClick={() => setDark((d) => !d)}
+              aria-label="Toggle theme"
+              className="inline-flex items-center rounded-md border p-1.5 hover:bg-accent"
+            >
+              <Icon name={dark ? "sun" : "moon"} size={14} />
+            </button>
+          </div>
+        </header>
+
+        <div className="flex min-h-0 flex-1">
+          {active && (
+            <aside className="w-60 shrink-0 overflow-y-auto border-r p-2">
+              {files.length === 0 ? (
+                <p className="p-2 text-xs text-muted-foreground">
+                  No <code>.prisma</code>, <code>.tsp</code>, <code>.arazzo</code> or <code>.asyncapi</code> files in this folder.
+                </p>
+              ) : (
+                <ul className="space-y-0.5">
+                  {files.map((f) => (
+                    <li key={f.id}>
+                      <button
+                        onClick={() => setOpen(f)}
+                        title={f.id}
+                        className={`flex w-full items-center gap-1.5 truncate rounded px-2 py-1 text-left text-sm hover:bg-accent ${
+                          open?.id === f.id ? "bg-accent font-medium" : ""
+                        }`}
+                      >
+                        <Icon name="file-text" size={14} className="shrink-0 text-muted-foreground" />
+                        <span className="truncate">{f.dir ? `${f.dir}/${f.name}` : f.name}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </aside>
+          )}
+
+          <main className="min-w-0 flex-1">
+            {!active && !supported ? (
+              <Centered>
+                <div className="max-w-sm space-y-3 text-center">
+                  <p>The File System Access API isn't available in this browser. Try Chrome, Edge or Arc — or explore a sample.</p>
+                  <button
+                    onClick={loadSample}
+                    className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:opacity-90"
+                  >
+                    <Icon name="sparkles" size={14} />
+                    Try a sample
+                  </button>
+                </div>
+              </Centered>
+            ) : !active ? (
+              <Centered>
+                <div className="max-w-sm space-y-3 text-center">
+                  <p>Open a folder containing <code>.prisma</code>, <code>.tsp</code>, <code>.arazzo</code> or <code>.asyncapi</code> files to edit them visually.</p>
+                  <div className="flex items-center justify-center gap-2">
+                    <button
+                      onClick={pickFolder}
+                      className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:opacity-90"
+                    >
+                      <Icon name="folder" size={14} />
+                      Open folder
+                    </button>
+                    <button
+                      onClick={loadSample}
+                      className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+                    >
+                      <Icon name="sparkles" size={14} />
+                      Try a sample
+                    </button>
+                  </div>
+                  {error && <p className="text-xs text-destructive">{error}</p>}
+                </div>
+              </Centered>
+            ) : open ? (
+              <ModelEditorFileRouter key={open.id} fileId={open.id} fileName={open.name} filePath={open.dir} />
+            ) : (
+              <Centered>Select a file to start editing.</Centered>
+            )}
+          </main>
+        </div>
+      </div>
+    </PluginHostProvider>
+  );
+}
+
+function Centered({ children }: { children: React.ReactNode }) {
+  return <div className="grid h-full place-items-center p-6 text-sm text-muted-foreground">{children}</div>;
+}
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/apps/model-editor-demo/src/main.tsx
+++ b/apps/model-editor-demo/src/main.tsx
@@ -99,7 +99,9 @@ function App() {
           <div className="ml-auto flex items-center gap-2">
             <button
               onClick={pickFolder}
-              className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm hover:bg-accent"
+              disabled={!supported}
+              title={supported ? undefined : "Your browser doesn't support opening local folders"}
+              className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Icon name="folder" size={14} />
               {root ? "Change folder" : "Open folder"}

--- a/apps/model-editor-demo/src/sample-bridge.ts
+++ b/apps/model-editor-demo/src/sample-bridge.ts
@@ -14,11 +14,16 @@ export function createSampleBridge(): HostBridge {
   const noop = async () => {};
   return {
     online: true,
-    readFileText: async (id) => text.get(id) ?? "",
+    readFileText: async (id) => {
+      const cur = text.get(id);
+      if (cur === undefined) throw new Error(`No such file: ${id}`);
+      return cur;
+    },
     saveFileVersion: async (id, next) => {
+      if (!text.has(id)) throw new Error(`No such file: ${id}`);
       text.set(id, next);
     },
-    getFile: async (id) => asFile(id),
+    getFile: async (id) => (text.has(id) ? asFile(id) : null),
     listFiles: async () => [...text.keys()].map(asFile),
     createFile: async (_dir, name, content) => {
       text.set(name, content ?? "");

--- a/apps/model-editor-demo/src/sample-bridge.ts
+++ b/apps/model-editor-demo/src/sample-bridge.ts
@@ -1,0 +1,44 @@
+import type { HostBridge, PluginFile } from "@canopy/plugin-sdk";
+import { SAMPLE_PROJECT } from "@canopy/model-editor";
+
+/**
+ * An in-memory {@link HostBridge} over the shared Pet Store sample
+ * ({@link SAMPLE_PROJECT}) — lets the demo run the full spec workspace (entities,
+ * endpoints, channels, flows) with no local folder. All files live in the root, so
+ * file ids are just their names. Edits are kept in memory and lost on reload.
+ */
+export function createSampleBridge(): HostBridge {
+  // Working copy so edits from the canvas round-trip within the session.
+  const text = new Map<string, string>(SAMPLE_PROJECT.map((f) => [f.name, f.content]));
+  const asFile = (name: string): PluginFile => ({ id: name, name, path: "" });
+  const noop = async () => {};
+  return {
+    online: true,
+    readFileText: async (id) => text.get(id) ?? "",
+    saveFileVersion: async (id, next) => {
+      text.set(id, next);
+    },
+    getFile: async (id) => asFile(id),
+    listFiles: async () => [...text.keys()].map(asFile),
+    createFile: async (_dir, name, content) => {
+      text.set(name, content ?? "");
+      return asFile(name);
+    },
+    createAndOpenFile: async () => null,
+    aiGenerate: async () => {
+      throw new Error("AI is not available in the sample");
+    },
+    listAiModels: async () => [],
+    getPluginSettings: async () => null,
+    savePluginSettings: noop,
+    getPluginPlaces: async () => [],
+    applySpacePlugin: noop,
+    removeSpacePlugin: noop,
+    listSpaces: async () => [],
+    syncConnector: async () => ({ ok: false }),
+    testConnector: async () => ({ ok: false }),
+    listMount: async () => [],
+    readMountText: async () => "",
+    mountFileUrl: () => "",
+  };
+}

--- a/apps/model-editor-demo/tsconfig.json
+++ b/apps/model-editor-demo/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": [],
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src"]
+}

--- a/apps/model-editor-demo/vite.config.ts
+++ b/apps/model-editor-demo/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+// A plain static single-page app: the Model Editor plugin rendered against a
+// HostBridge backed by the browser's File System Access API. No backend.
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+});

--- a/apps/portal/src/plugins/index.tsx
+++ b/apps/portal/src/plugins/index.tsx
@@ -9,10 +9,11 @@ import { DocumentAiView } from "./document-ai-view";
 // Lazy-loaded: pulls react-markdown + remark-gfm into a separate chunk.
 const DocumentationView = lazy(() => import("./documentation-view").then((m) => ({ default: m.DocumentationView })));
 // Model Editor is a trusted first-party React app (React Flow) bound to file types
-// only — it's a viewer/editor for `.prisma`/`.tsp`/`.arazzo`, not a standalone app.
-// Lazy so its heavy deps stay out of the main bundle until a matching file opens.
-// Routes a matched file to the right canvas: `.prisma` → the Prisma model editor,
-// `.tsp`/`.arazzo` → the spec editor (TypeSpec + Arazzo, with cross-layer links).
+// only — it's a viewer/editor for `.prisma`/`.tsp`/`.arazzo`/`.asyncapi`, not a
+// standalone app. Lazy so its heavy deps stay out of the main bundle until a
+// matching file opens. Routes a matched file to the right canvas: `.prisma` → the
+// Prisma model editor, `.tsp`/`.arazzo`/`.asyncapi` → the spec editor (TypeSpec +
+// Arazzo + AsyncAPI, with cross-layer links).
 const ModelEditorFileView = lazy(() =>
   import("@canopy/model-editor").then((m) => ({ default: m.ModelEditorFileRouter })),
 );

--- a/apps/vscode-model-editor/README.md
+++ b/apps/vscode-model-editor/README.md
@@ -8,6 +8,7 @@ data-model and API files in a visual editor instead of plain text:
 | `.prisma` | Visual Prisma schema / ER editor |
 | `.tsp` | TypeSpec entities + endpoints |
 | `.arazzo`, `.arazzo.yaml/.yml/.json` | Arazzo workflow builder |
+| `.asyncapi`, `.asyncapi.yaml/.yml/.json` | AsyncAPI channels (events) |
 
 The UI is the exact same React component tree (`@canopy/model-editor`) used by the
 Canopy portal. The only thing that differs per host is the `HostBridge`: in the
@@ -29,9 +30,9 @@ code --install-extension canopy-model-editor.vsix
 
 Run **Canopy Model Editor: Create Sample Project** from the Command Palette (or the
 "Create a sample project" button in the extension's Walkthrough) to drop a small
-Pet Store project — `schema.prisma`, `main.tsp`, `workflow.arazzo.yaml` — into a
-folder and open it in the editor. Or just open any existing `.prisma` / `.tsp` /
-`.arazzo` file.
+Pet Store project — `schema.prisma`, `main.tsp`, `workflow.arazzo.yaml`,
+`events.asyncapi.yaml` — into a folder and open it in the editor. Or just open any
+existing `.prisma` / `.tsp` / `.arazzo` / `.asyncapi` file.
 
 ## How it works
 
@@ -55,9 +56,15 @@ pnpm --filter canopy-model-editor build
 ```
 
 Then press **F5** (Run "Run Model Editor Extension") to launch an Extension
-Development Host, and open a `.prisma` / `.tsp` / `.arazzo` file. For iterative
-work run `pnpm --filter canopy-model-editor watch:host` and `watch:webview` in
-parallel.
+Development Host, and open a `.prisma` / `.tsp` / `.arazzo` / `.asyncapi` file. For iterative
+work run both watchers (host + webview) in one terminal:
+
+```sh
+pnpm --filter canopy-model-editor dev
+```
+
+After a host (`src/*.ts`) change, reload the dev-host window (`Cmd+R`); after a
+webview change, just reopen the file's editor tab.
 
 ## Package
 

--- a/apps/vscode-model-editor/README.md
+++ b/apps/vscode-model-editor/README.md
@@ -14,6 +14,17 @@ Canopy portal. The only thing that differs per host is the `HostBridge`: in the
 portal it talks to the Canopy API; here it talks to the VS Code extension host
 over `postMessage`.
 
+## Install
+
+Download `canopy-model-editor.vsix` from the
+[latest release](https://github.com/markusahlstrand/canopy/releases/latest), then:
+
+```sh
+code --install-extension canopy-model-editor.vsix
+```
+
+…or in VS Code: **Extensions panel → ⋯ → Install from VSIX…**.
+
 ## Get started
 
 Run **Canopy Model Editor: Create Sample Project** from the Command Palette (or the

--- a/apps/vscode-model-editor/package.json
+++ b/apps/vscode-model-editor/package.json
@@ -37,7 +37,11 @@
           { "filenamePattern": "*.arazzo" },
           { "filenamePattern": "*.arazzo.yaml" },
           { "filenamePattern": "*.arazzo.yml" },
-          { "filenamePattern": "*.arazzo.json" }
+          { "filenamePattern": "*.arazzo.json" },
+          { "filenamePattern": "*.asyncapi" },
+          { "filenamePattern": "*.asyncapi.yaml" },
+          { "filenamePattern": "*.asyncapi.yml" },
+          { "filenamePattern": "*.asyncapi.json" }
         ],
         "priority": "default"
       }
@@ -58,19 +62,19 @@
       {
         "id": "canopy.modelEditor.getStarted",
         "title": "Canopy Model Editor",
-        "description": "Visually edit Prisma schemas, TypeSpec APIs and Arazzo workflows.",
+        "description": "Visually edit Prisma schemas, TypeSpec APIs, Arazzo workflows and AsyncAPI events.",
         "steps": [
           {
             "id": "createSample",
             "title": "Create a sample project",
-            "description": "Generate a ready-to-edit Pet Store project (.prisma, .tsp and .arazzo) in a folder.\n[Create Sample Project](command:canopy.modelEditor.createSample)",
+            "description": "Generate a ready-to-edit Pet Store project (.prisma, .tsp, .arazzo and .asyncapi) in a folder.\n[Create Sample Project](command:canopy.modelEditor.createSample)",
             "media": { "image": "icon.png", "altText": "Canopy Model Editor" },
             "completionEvents": ["onCommand:canopy.modelEditor.createSample"]
           },
           {
             "id": "openFile",
             "title": "Open a model file",
-            "description": "Open any .prisma, .tsp or .arazzo file — it opens in the visual editor automatically. To see the raw text, right-click the tab → Reopen Editor With… → Text Editor.",
+            "description": "Open any .prisma, .tsp, .arazzo or .asyncapi file — it opens in the visual editor automatically. To see the raw text, right-click the tab → Reopen Editor With… → Text Editor.",
             "media": { "image": "icon.png", "altText": "Canopy Model Editor" }
           }
         ]
@@ -83,6 +87,7 @@
     "build": "pnpm run build:host && pnpm run build:webview",
     "watch:host": "node esbuild.mjs --watch",
     "watch:webview": "vite build --watch",
+    "dev": "concurrently -n host,webview -c blue,green \"pnpm run watch:host\" \"pnpm run watch:webview\"",
     "typecheck": "tsc --noEmit",
     "package": "pnpm run build && vsce package --no-dependencies -o canopy-model-editor.vsix"
   },
@@ -97,6 +102,7 @@
     "@types/vscode": "^1.95.0",
     "@vitejs/plugin-react": "^6.0.2",
     "@vscode/vsce": "^3.6.0",
+    "concurrently": "^9.2.1",
     "esbuild": "^0.25.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/apps/vscode-model-editor/src/editorProvider.ts
+++ b/apps/vscode-model-editor/src/editorProvider.ts
@@ -5,7 +5,7 @@ import * as files from "./files";
 import type { HostMethod, HostToWebview, WebviewToHost } from "./messages";
 
 /**
- * A custom editor that opens `.prisma` / `.tsp` / `.arazzo` files in the Canopy
+ * A custom editor that opens `.prisma` / `.tsp` / `.arazzo` / `.asyncapi` files in the Canopy
  * Model Editor webview. The extension host owns the {@link vscode.TextDocument};
  * the webview is the UI and talks to it over postMessage (see ./messages.ts).
  * Saving from the canvas replaces the document text and persists it; external/text

--- a/apps/vscode-model-editor/src/files.ts
+++ b/apps/vscode-model-editor/src/files.ts
@@ -6,7 +6,7 @@ import type { PluginFile } from "@canopy/plugin-sdk";
  * Maps the model-editor's file capabilities onto the workspace filesystem. The
  * plugin treats files by opaque "id" and folders by "dir"; in VS Code both are
  * just filesystem paths (`Uri.fsPath`). The spec editor uses these to discover
- * sibling `.tsp`/`.arazzo`/`.json` files and to write its sidecar — so backing
+ * sibling `.tsp`/`.arazzo`/`.asyncapi`/`.json` files and to write its sidecar — so backing
  * them with `vscode.workspace.fs` makes cross-layer linking work for real.
  */
 

--- a/apps/vscode-model-editor/src/sample.ts
+++ b/apps/vscode-model-editor/src/sample.ts
@@ -1,131 +1,42 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
+import { SAMPLE_PROJECT, SAMPLE_ENTRYPOINT } from "@canopy/model-editor";
 import { writeFile } from "./files";
 import { ModelEditorProvider } from "./editorProvider";
 
 /**
- * A small, coherent starter project that shows off all three editors at once,
- * built around the Pet Store — the canonical API example. A Prisma schema (with a
- * relation), a TypeSpec API, and an Arazzo workflow that links back to the API via
- * `x-typespec-source` + matching operation ids. The contents mirror the
- * model-editor's own creator templates, so they're guaranteed to parse.
+ * The shared "Pet Store" starter project (see {@link SAMPLE_PROJECT}) plus a
+ * VS Code-specific README. One contract (`main.tsp`) projected across the spec
+ * workspace, with an `openapi.yaml` the workflow resolves to, two Arazzo workflows,
+ * and an AsyncAPI document whose channels link back to the entities and endpoints —
+ * everything cross-links by id, so the sample doubles as a tour of find-usages.
  */
-const SAMPLE_FILES: { name: string; content: string }[] = [
-  {
-    name: "schema.prisma",
-    content: `// Sample Prisma schema — open in the Canopy Model Editor to edit it visually.
-// Drag entities, draw relations, then export to SQL / JSON Schema / Mermaid.
+const README = `# Canopy Model Editor — Pet Store sample
 
-datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
-}
+A coherent Pet Store across every editor. Open **main.tsp** and use the tabs
+(Entities · Endpoints · Channels · Flows · Source) — clicking any item highlights
+what references it in the other layers.
 
-generator client {
-  provider = "prisma-client-js"
-}
+- **schema.prisma** — a Prisma data model (\`Owner\` → \`Pet\` → \`Visit\`). Drag
+  entities, draw relations, and export to SQL / JSON Schema / Mermaid.
+- **main.tsp** — the TypeSpec contract: \`Owner\`, \`Pet\` and \`Visit\` entities plus
+  CRUD operations grouped under the \`owners\`, \`pets\` and \`visits\` tags.
+- **openapi.yaml** — the OpenAPI the contract emits; the workflow's
+  \`sourceDescriptions\` resolve to it.
+- **workflow.arazzo.yaml** — two Arazzo workflows (\`onboardCustomer\`,
+  \`findAndBook\`) whose steps call the operations above; \`x-typespec-source\` links
+  them back to \`main.tsp\` so the editor can trace steps → endpoints → entities.
+- **events.asyncapi.yaml** — AsyncAPI channels whose message payloads link to the
+  \`Pet\` and \`Visit\` entities, bound to the \`getPet\` / \`bookVisit\` endpoints —
+  surfaced in the **Channels** tab.
 
-model Owner {
-  id        String   @id @default(cuid())
-  name      String
-  email     String   @unique
-  pets      Pet[]
-  createdAt DateTime @default(now())
-}
-
-model Pet {
-  id        String   @id @default(cuid())
-  name      String
-  status    String   @default("available")
-  owner     Owner?   @relation(fields: [ownerId], references: [id])
-  ownerId   String?
-  createdAt DateTime @default(now())
-}
-`,
-  },
-  {
-    name: "main.tsp",
-    content: `import "@typespec/http";
-
-using TypeSpec.Http;
-
-@service(#{ title: "Pet Store" })
-namespace PetStore;
-
-model Pet {
-  @key id: string;
-  name: string;
-  status: string;
-}
-
-@route("/pets")
-interface Pets {
-  @get
-  @operationId("listPets")
-  list(): Pet[];
-
-  @get
-  @operationId("getPet")
-  read(@path id: string): Pet;
-}
-`,
-  },
-  {
-    name: "workflow.arazzo.yaml",
-    content: `arazzo: 1.0.1
-info:
-  title: Find a pet
-  version: 1.0.0
-# x-typespec-source links this workflow back to the TypeSpec contract so the editor
-# can trace steps -> endpoints -> entities across the .tsp and .arazzo files.
-x-typespec-source: ./main.tsp
-sourceDescriptions:
-  - name: api
-    url: ./openapi.yaml
-    type: openapi
-workflows:
-  - workflowId: findPet
-    summary: List pets, then fetch the first one.
-    steps:
-      - stepId: listPets
-        description: Get all pets.
-        operationId: listPets
-        successCriteria:
-          - condition: $statusCode == 200
-        outputs:
-          pets: $response.body
-      - stepId: getPet
-        description: Fetch a single pet by id.
-        operationId: getPet
-        parameters:
-          - name: id
-            in: path
-            value: $steps.listPets.outputs.pets[0].id
-        successCriteria:
-          - condition: $statusCode == 200
-        outputs:
-          pet: $response.body
-    outputs:
-      pet: $steps.getPet.outputs.pet
-`,
-  },
-  {
-    name: "README.md",
-    content: `# Canopy Model Editor — Pet Store sample
-
-Three files, each opening in its own visual editor:
-
-- **schema.prisma** — a Prisma data model (\`Owner\` 1—N \`Pet\`). Drag entities,
-  draw relations, and export to SQL / JSON Schema / Mermaid.
-- **main.tsp** — a TypeSpec Pet Store API with a model and two operations.
-- **workflow.arazzo.yaml** — an Arazzo workflow whose steps reference the API's
-  operations; \`x-typespec-source\` links it back to \`main.tsp\` so the editor can
-  trace steps → endpoints → entities.
-
-Open any file to start editing. To see the raw text, right-click the tab →
+To see the raw text of any file, right-click the tab →
 **Reopen Editor With… → Text Editor**.
-`,
-  },
+`;
+
+const SAMPLE_FILES: { name: string; content: string }[] = [
+  ...SAMPLE_PROJECT,
+  { name: "README.md", content: README },
 ];
 
 /** Where to drop the sample, asking the user when it's ambiguous. */
@@ -169,10 +80,11 @@ export async function createSampleProject(): Promise<void> {
 
   await Promise.all(SAMPLE_FILES.map((f) => writeFile(path.join(baseDir, f.name), f.content)));
 
-  // Open the Prisma schema in the visual editor to get the user going immediately.
+  // Open the contract in the spec workspace so the user lands on the cross-linked
+  // Entities · Endpoints · Channels · Flows tabs straight away.
   await vscode.commands.executeCommand(
     "vscode.openWith",
-    vscode.Uri.file(path.join(baseDir, "schema.prisma")),
+    vscode.Uri.file(path.join(baseDir, "main.tsp")),
     ModelEditorProvider.viewType,
   );
   vscode.window.showInformationMessage(`Pet Store sample project created in ${baseDir}.`);

--- a/apps/vscode-model-editor/src/sample.ts
+++ b/apps/vscode-model-editor/src/sample.ts
@@ -14,7 +14,7 @@ import { ModelEditorProvider } from "./editorProvider";
 const README = `# Canopy Model Editor — Pet Store sample
 
 A coherent Pet Store across every editor. Open **main.tsp** and use the tabs
-(Entities · Endpoints · Channels · Flows · Source) — clicking any item highlights
+(Entities · Endpoints · Events · Flows · Source) — clicking any item highlights
 what references it in the other layers.
 
 - **schema.prisma** — a Prisma data model (\`Owner\` → \`Pet\` → \`Visit\`). Drag
@@ -28,7 +28,7 @@ what references it in the other layers.
   them back to \`main.tsp\` so the editor can trace steps → endpoints → entities.
 - **events.asyncapi.yaml** — AsyncAPI channels whose message payloads link to the
   \`Pet\` and \`Visit\` entities, bound to the \`getPet\` / \`bookVisit\` endpoints —
-  surfaced in the **Channels** tab.
+  surfaced in the **Events** tab.
 
 To see the raw text of any file, right-click the tab →
 **Reopen Editor With… → Text Editor**.
@@ -81,7 +81,7 @@ export async function createSampleProject(): Promise<void> {
   await Promise.all(SAMPLE_FILES.map((f) => writeFile(path.join(baseDir, f.name), f.content)));
 
   // Open the contract in the spec workspace so the user lands on the cross-linked
-  // Entities · Endpoints · Channels · Flows tabs straight away.
+  // Entities · Endpoints · Events · Flows tabs straight away.
   await vscode.commands.executeCommand(
     "vscode.openWith",
     vscode.Uri.file(path.join(baseDir, "main.tsp")),

--- a/apps/vscode-model-editor/src/sample.ts
+++ b/apps/vscode-model-editor/src/sample.ts
@@ -84,7 +84,7 @@ export async function createSampleProject(): Promise<void> {
   // Entities · Endpoints · Events · Flows tabs straight away.
   await vscode.commands.executeCommand(
     "vscode.openWith",
-    vscode.Uri.file(path.join(baseDir, "main.tsp")),
+    vscode.Uri.file(path.join(baseDir, SAMPLE_ENTRYPOINT)),
     ModelEditorProvider.viewType,
   );
   vscode.window.showInformationMessage(`Pet Store sample project created in ${baseDir}.`);

--- a/examples/plugins/model-editor/canopy.json
+++ b/examples/plugins/model-editor/canopy.json
@@ -28,6 +28,13 @@
         "match": [".arazzo", ".arazzo.yaml", ".arazzo.yml", ".arazzo.json"],
         "fill": true,
         "immersive": true
+      },
+      {
+        "id": "asyncapi",
+        "title": "Spec Editor",
+        "match": [".asyncapi", ".asyncapi.yaml", ".asyncapi.yml", ".asyncapi.json"],
+        "fill": true,
+        "immersive": true
       }
     ],
     "creators": [
@@ -57,6 +64,15 @@
         "extension": ".arazzo.yaml",
         "mime": "application/yaml",
         "template": "arazzo: 1.0.1\ninfo:\n  title: My workflow\n  version: 1.0.0\n# Point sourceDescriptions at the OpenAPI your .tsp emits; x-typespec-source links\n# back to the contract so the editor can trace steps → endpoints → entities.\nx-typespec-source: ./main.tsp\nsourceDescriptions:\n  - name: api\n    url: ./openapi.yaml\n    type: openapi\nworkflows:\n  - workflowId: myWorkflow\n    summary: Describe what this flow does.\n    steps:\n      - stepId: firstStep\n        description: Call an operation from the source above.\n        operationId: listItems\n        successCriteria:\n          - condition: $statusCode == 200\n        outputs:\n          result: $response.body\n    outputs:\n      result: $steps.firstStep.outputs.result\n"
+      },
+      {
+        "id": "asyncapi",
+        "label": "AsyncAPI events",
+        "icon": "radio",
+        "defaultName": "events",
+        "extension": ".asyncapi.yaml",
+        "mime": "application/yaml",
+        "template": "asyncapi: 3.0.0\ninfo:\n  title: My events\n  version: 1.0.0\n# Message payloads that $ref a schema named like a .tsp model link to that entity;\n# an x-operationId (or a channel address matching an endpoint route) links to an endpoint.\nservers:\n  live:\n    host: example.com\n    protocol: sse\nchannels:\n  itemEvents:\n    address: /items/events\n    servers:\n      - $ref: '#/servers/live'\n    messages:\n      itemChanged:\n        $ref: '#/components/messages/ItemChanged'\noperations:\n  receiveItemChanged:\n    action: receive\n    channel:\n      $ref: '#/channels/itemEvents'\n    messages:\n      - $ref: '#/channels/itemEvents/messages/itemChanged'\ncomponents:\n  messages:\n    ItemChanged:\n      summary: An item was created or updated.\n      payload:\n        $ref: '#/components/schemas/Item'\n  schemas:\n    Item:\n      type: object\n"
       }
     ],
     "store": {

--- a/packages/connectors/github/src/index.ts
+++ b/packages/connectors/github/src/index.ts
@@ -71,6 +71,15 @@ export function createGithubConnector(id: string, config: GithubConnectorConfig)
     } catch {
       /* non-JSON body — fall back to the status */
     }
+    // A 403 with the rate-limit counter at zero means the unauthenticated quota
+    // (60 req/hr per IP) is spent — common during extract on a token-less deploy.
+    // Point at the fix (set a token) instead of leaving a bare "403".
+    if (res.status === 403 && res.headers.get("x-ratelimit-remaining") === "0") {
+      const reset = res.headers.get("x-ratelimit-reset");
+      const when = reset ? ` (resets at ${new Date(Number(reset) * 1000).toISOString()})` : "";
+      const hint = config.token ? "" : " — set GITHUB_TOKEN to raise the limit";
+      detail = `: rate limit exceeded${when}${hint}`;
+    }
     return new Error(`github ${verb} failed (${res.status})${detail}`);
   }
 
@@ -138,7 +147,7 @@ export function createGithubConnector(id: string, config: GithubConnectorConfig)
     async list(path): Promise<Page<StorageEntry>> {
       const res = await contents(repoPath(path));
       if (res.status === 404) return { items: [] };
-      if (!res.ok) throw new Error(`github list failed: ${res.status}`);
+      if (!res.ok) throw await ghError(res, "list");
       const data = (await res.json()) as GhContentItem | GhContentItem[];
       const arr = Array.isArray(data) ? data : [data];
       const items: StorageEntry[] = arr.map((it) => ({
@@ -154,7 +163,7 @@ export function createGithubConnector(id: string, config: GithubConnectorConfig)
     async stat(path): Promise<StorageEntry | null> {
       const res = await contents(repoPath(path));
       if (res.status === 404) return null;
-      if (!res.ok) throw new Error(`github stat failed: ${res.status}`);
+      if (!res.ok) throw await ghError(res, "stat");
       const data = (await res.json()) as GhContentItem | GhContentItem[];
       if (Array.isArray(data)) {
         const name = path.split("/").filter(Boolean).pop() ?? "";
@@ -166,7 +175,7 @@ export function createGithubConnector(id: string, config: GithubConnectorConfig)
     async read(path): Promise<ReadableStream<Uint8Array>> {
       // Raw media type streams the file directly (works for private repos too).
       const res = await contents(repoPath(path), "application/vnd.github.raw");
-      if (!res.ok || !res.body) throw new Error(`github read failed: ${res.status}`);
+      if (!res.ok || !res.body) throw await ghError(res, "read");
       return res.body as ReadableStream<Uint8Array>;
     },
 

--- a/packages/connectors/github/src/index.ts
+++ b/packages/connectors/github/src/index.ts
@@ -75,8 +75,10 @@ export function createGithubConnector(id: string, config: GithubConnectorConfig)
     // (60 req/hr per IP) is spent — common during extract on a token-less deploy.
     // Point at the fix (set a token) instead of leaving a bare "403".
     if (res.status === 403 && res.headers.get("x-ratelimit-remaining") === "0") {
-      const reset = res.headers.get("x-ratelimit-reset");
-      const when = reset ? ` (resets at ${new Date(Number(reset) * 1000).toISOString()})` : "";
+      const reset = Number(res.headers.get("x-ratelimit-reset"));
+      // Only format when the header parsed to a real epoch — a bogus value must not
+      // throw here and mask the underlying GitHub failure.
+      const when = Number.isFinite(reset) && reset > 0 ? ` (resets at ${new Date(reset * 1000).toISOString()})` : "";
       const hint = config.token ? "" : " — set GITHUB_TOKEN to raise the limit";
       detail = `: rate limit exceeded${when}${hint}`;
     }

--- a/packages/model-editor/package.json
+++ b/packages/model-editor/package.json
@@ -17,6 +17,7 @@
     "@canopy/plugin-sdk": "workspace:*",
     "@canopy/ui": "workspace:*",
     "@xyflow/react": "^12.11.0",
+    "elkjs": "^0.11.1",
     "idb": "^8.0.3",
     "js-yaml": "^4.2.0"
   },

--- a/packages/model-editor/src/assistant-panel.tsx
+++ b/packages/model-editor/src/assistant-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import {
   Button,
   Select,
@@ -65,7 +65,7 @@ export interface AssistantPanelProps {
   onApply: (model: unknown) => void;
 }
 
-export function AssistantPanel({ getModel, onApply }: AssistantPanelProps) {
+export const AssistantPanel = memo(function AssistantPanel({ getModel, onApply }: AssistantPanelProps) {
   const host = usePluginHost();
   const [models, setModels] = useState<AiModel[] | null>(null);
   const [modelId, setModelId] = useState<string>("");
@@ -223,7 +223,7 @@ export function AssistantPanel({ getModel, onApply }: AssistantPanelProps) {
       </div>
     </div>
   );
-}
+});
 
 function Dot() {
   return <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-duration:1s]" />;

--- a/packages/model-editor/src/export-panel.tsx
+++ b/packages/model-editor/src/export-panel.tsx
@@ -1,22 +1,26 @@
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { Button } from "@canopy/ui";
 import { Icon } from "@canopy/ui";
 import { cn } from "@canopy/ui";
 import { EXPORT_TARGETS, type ExportFormat } from "./export";
 import type { DomainModel } from "./types";
 
-export function ExportPanel({ model }: { model: DomainModel }) {
+export const ExportPanel = memo(function ExportPanel({ model, active = true }: { model: DomainModel; active?: boolean }) {
   const [format, setFormat] = useState<ExportFormat>("json");
   const [copied, setCopied] = useState(false);
 
   const target = EXPORT_TARGETS.find((t) => t.id === format)!;
+  // Serialising the whole model is expensive; skip it while the panel is hidden
+  // so dragging nodes (which churns `model` every frame) stays smooth. It
+  // recomputes as soon as the tab becomes active.
   const code = useMemo(() => {
+    if (!active) return "";
     try {
       return target.render(model);
     } catch (e) {
       return `// Export failed: ${e instanceof Error ? e.message : String(e)}`;
     }
-  }, [target, model]);
+  }, [target, model, active]);
 
   function copy() {
     navigator.clipboard.writeText(code).then(
@@ -75,4 +79,4 @@ export function ExportPanel({ model }: { model: DomainModel }) {
       </pre>
     </div>
   );
-}
+});

--- a/packages/model-editor/src/file-router.tsx
+++ b/packages/model-editor/src/file-router.tsx
@@ -1,7 +1,7 @@
 import { Suspense, lazy } from "react";
 import type { FileViewProps } from "@canopy/plugin-sdk";
 import { Icon } from "@canopy/ui";
-import { isArazzo, isTsp } from "./spec/discover";
+import { isArazzo, isAsyncApi, isTsp } from "./spec/discover";
 
 // Both canvases are heavy (React Flow + parsers), so keep each in its own lazy chunk
 // and only pull in the one the opened file needs.
@@ -16,11 +16,11 @@ const Spinner = () => (
 
 /**
  * Dispatches a file the Model Editor plugin claims to the right canvas by extension:
- * `.tsp`/`.arazzo` open the spec editor (TypeSpec + Arazzo with cross-layer links),
- * everything else (`.prisma`) opens the Prisma model editor.
+ * `.tsp`/`.arazzo`/`.asyncapi` open the spec editor (TypeSpec + Arazzo + AsyncAPI with
+ * cross-layer links), everything else (`.prisma`) opens the Prisma model editor.
  */
 export function ModelEditorFileRouter(props: FileViewProps) {
-  const spec = isTsp(props.fileName) || isArazzo(props.fileName);
+  const spec = isTsp(props.fileName) || isArazzo(props.fileName) || isAsyncApi(props.fileName);
   return (
     <Suspense fallback={<Spinner />}>{spec ? <SpecFileViewer {...props} /> : <PrismaFileViewer {...props} />}</Suspense>
   );

--- a/packages/model-editor/src/index.ts
+++ b/packages/model-editor/src/index.ts
@@ -1,6 +1,9 @@
 // Public surface of the Model Editor plugin: the file router (dispatches a
-// .prisma/.tsp/.arazzo file to the right canvas) and the domain-model
+// .prisma/.tsp/.arazzo/.asyncapi file to the right canvas) and the domain-model
 // vocabulary. Hosts (the Canopy portal, the VS Code extension) render
 // `ModelEditorFileRouter` inside a `PluginHostProvider` and supply a HostBridge.
 export { ModelEditorFileRouter } from "./file-router";
 export * from "./types";
+// The shared "Pet Store" starter project, used by the VS Code "Create Sample
+// Project" command and the demo's "Try a sample" so the two stay in sync.
+export { SAMPLE_PROJECT, SAMPLE_ENTRYPOINT, type SampleFile } from "./sample-project";

--- a/packages/model-editor/src/inspector.tsx
+++ b/packages/model-editor/src/inspector.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Button } from "@canopy/ui";
 import { Checkbox } from "@canopy/ui";
 import { Input } from "@canopy/ui";
@@ -47,7 +48,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   );
 }
 
-export function Inspector(props: InspectorProps) {
+export const Inspector = memo(function Inspector(props: InspectorProps) {
   const { entity, relation, entities } = props;
 
   if (!entity && !relation) {
@@ -221,7 +222,7 @@ export function Inspector(props: InspectorProps) {
       </div>
     </div>
   );
-}
+});
 
 function PropertyRow({
   prop,

--- a/packages/model-editor/src/model-editor-view.tsx
+++ b/packages/model-editor/src/model-editor-view.tsx
@@ -16,6 +16,8 @@ import {
   type Node,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import "./model-editor.css";
+import { onNodeDragStart, onNodeDragStop } from "./node-drag-cursor";
 import {
   Button,
   Checkbox,
@@ -74,6 +76,12 @@ const defaultEdgeOptions = {
   markerEnd: { type: MarkerType.ArrowClosed, width: 18, height: 18 },
   style: { strokeWidth: 1.5 },
 };
+
+// Hoisted so their identity is stable across renders — passing fresh array/object
+// literals here makes React Flow re-process them on every drag frame (flicker).
+const deleteKeyCodes = ["Backspace", "Delete"];
+const proOptions = { hideAttribution: true };
+const miniMapNodeColor = (n: Node) => ACCENTS[(n.data as EntityNodeData).color ?? "zinc"].dot;
 
 type Selection = { type: "entity" | "relation"; id: string } | null;
 type RightTab = "assistant" | "inspector" | "export";
@@ -142,6 +150,11 @@ function flowToModel(nodes: Node[], edges: Edge[], name: string): DomainModel {
 }
 
 const emptyModel = (): DomainModel => ({ name: "Untitled model", version: 1, entities: [], relations: [] });
+
+// A single stable model reference handed to the (memoised) ExportPanel while it's
+// hidden, so dragging nodes never re-renders it; the live model flows in only when
+// the Export tab is active.
+const EXPORT_IDLE_MODEL = emptyModel();
 
 /** Load the saved library, seeding a blank model on first run. */
 function bootstrap(): { models: StoredModel[]; current: StoredModel } {
@@ -212,6 +225,16 @@ function Editor({ file }: { file?: FileBinding }) {
 
   const model = useMemo(() => flowToModel(nodes, edges, name), [nodes, edges, name]);
 
+  // Mirror the live model/nodes in refs so callbacks can read the latest values
+  // without listing them as deps. That keeps handlers passed to the side panels
+  // stable across renders, so dragging a node (which churns `nodes` every frame)
+  // re-renders only React Flow, not the whole editor tree.
+  const modelRef = useRef(model);
+  modelRef.current = model;
+  const nodesRef = useRef(nodes);
+  nodesRef.current = nodes;
+  const getModel = useCallback(() => modelRef.current, []);
+
   // ── File mode: track unsaved changes; save serialises the canvas to Prisma ──
   useEffect(() => {
     if (!fileMode) return;
@@ -227,7 +250,7 @@ function Editor({ file }: { file?: FileBinding }) {
       if (!file?.onSave || saving) return;
       setSaving(true);
       try {
-        await file.onSave(toPrisma(model, { metadata: embed }));
+        await file.onSave(toPrisma(modelRef.current, { metadata: embed }));
         setDirty(false);
       } catch {
         toast.error("Couldn't save the file");
@@ -235,7 +258,7 @@ function Editor({ file }: { file?: FileBinding }) {
         setSaving(false);
       }
     },
-    [file, model, saving],
+    [file, saving],
   );
 
   const saveToFile = useCallback(() => {
@@ -535,7 +558,7 @@ function Editor({ file }: { file?: FileBinding }) {
         return;
       }
       // Keep manual positions for entities that still exist (matched by name).
-      const prevPos = new Map(nodes.map((n) => [data(n).name.toLowerCase(), n.position]));
+      const prevPos = new Map(nodesRef.current.map((n) => [data(n).name.toLowerCase(), n.position]));
       if (!opts.layoutFresh) {
         for (const e of parsed.entities) {
           const p = prevPos.get(e.name.toLowerCase());
@@ -551,7 +574,7 @@ function Editor({ file }: { file?: FileBinding }) {
       setSelection(null);
       setTimeout(() => fitView({ padding: 0.2, duration: 400 }), 60);
     },
-    [nodes, setNodes, setEdges, fitView],
+    [setNodes, setEdges, fitView],
   );
 
   // ── Toolbar actions ──
@@ -596,31 +619,47 @@ function Editor({ file }: { file?: FileBinding }) {
   );
 
   // ── Derived inspector inputs ──
-  const selectedEntity =
-    selection?.type === "entity"
-      ? (() => {
-          const n = nodes.find((x) => x.id === selection.id);
-          return n ? { id: n.id, data: data(n) } : null;
-        })()
-      : null;
+  // Memoised on the data that the inspector actually shows — entity/relation
+  // identity, names, properties — but NOT on node positions, so dragging a node
+  // (which replaces the node object every frame) doesn't re-render the inspector.
+  const selectedNode = selection?.type === "entity" ? nodes.find((x) => x.id === selection.id) ?? null : null;
+  const selectedNodeData = selectedNode ? data(selectedNode) : null;
+  const selectedEntity = useMemo(
+    () => (selectedNode ? { id: selectedNode.id, data: selectedNodeData! } : null),
+    [selectedNode?.id, selectedNodeData],
+  );
 
-  const selectedRelation =
-    selection?.type === "relation"
-      ? (() => {
-          const e = edges.find((x) => x.id === selection.id);
-          if (!e) return null;
-          const from = nodes.find((n) => n.id === e.source);
-          const to = nodes.find((n) => n.id === e.target);
-          return {
-            id: e.id,
-            data: (e.data ?? { cardinality: "1-N" }) as RelationData,
-            fromName: from ? data(from).name : "?",
-            toName: to ? data(to).name : "?",
-          };
-        })()
-      : null;
+  const selectedEdge = selection?.type === "relation" ? edges.find((x) => x.id === selection.id) ?? null : null;
+  const fromNode = selectedEdge ? nodes.find((n) => n.id === selectedEdge.source) : undefined;
+  const toNode = selectedEdge ? nodes.find((n) => n.id === selectedEdge.target) : undefined;
+  const fromName = fromNode ? data(fromNode).name : "?";
+  const toName = toNode ? data(toNode).name : "?";
+  const selectedRelation = useMemo(
+    () =>
+      selectedEdge
+        ? { id: selectedEdge.id, data: (selectedEdge.data ?? { cardinality: "1-N" }) as RelationData, fromName, toName }
+        : null,
+    [selectedEdge?.id, selectedEdge?.data, fromName, toName],
+  );
 
-  const entityList = useMemo(() => nodes.map((n) => ({ id: n.id, name: data(n).name })), [nodes]);
+  // Stable across position-only changes: only the id/name pairs matter here.
+  const entitySig = nodes.map((n) => `${n.id}:${data(n).name}`).join("|");
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- entitySig captures the relevant content of `nodes`
+  const entityList = useMemo(() => nodes.map((n) => ({ id: n.id, name: data(n).name })), [entitySig]);
+
+  // Stable canvas handlers — inline arrows here would change identity every drag
+  // frame and force React Flow to re-render the whole canvas (flicker).
+  const onNodeClick = useCallback((_: unknown, n: Node) => {
+    setSelection({ type: "entity", id: n.id });
+    setTab("inspector");
+    setPanelOpen(true);
+  }, []);
+  const onEdgeClick = useCallback((_: unknown, e: Edge) => {
+    setSelection({ type: "relation", id: e.id });
+    setTab("inspector");
+    setPanelOpen(true);
+  }, []);
+  const onPaneClick = useCallback(() => setSelection(null), []);
 
   return (
     <div className="flex h-full w-full flex-col bg-background">
@@ -768,28 +807,22 @@ function Editor({ file }: { file?: FileBinding }) {
             nodeTypes={nodeTypes}
             defaultEdgeOptions={defaultEdgeOptions}
             colorMode={colorMode}
-            onNodeClick={(_, n) => {
-              setSelection({ type: "entity", id: n.id });
-              setTab("inspector");
-              setPanelOpen(true);
-            }}
-            onEdgeClick={(_, e) => {
-              setSelection({ type: "relation", id: e.id });
-              setTab("inspector");
-              setPanelOpen(true);
-            }}
-            onPaneClick={() => setSelection(null)}
-            deleteKeyCode={["Backspace", "Delete"]}
+            onNodeClick={onNodeClick}
+            onEdgeClick={onEdgeClick}
+            onPaneClick={onPaneClick}
+            onNodeDragStart={onNodeDragStart}
+            onNodeDragStop={onNodeDragStop}
+            deleteKeyCode={deleteKeyCodes}
             fitView
             minZoom={0.2}
-            proOptions={{ hideAttribution: true }}
+            proOptions={proOptions}
           >
             <Background variant={BackgroundVariant.Dots} gap={18} size={1} />
             <Controls showInteractive={false} />
             <MiniMap
               pannable
               zoomable
-              nodeColor={(n) => ACCENTS[(n.data as EntityNodeData).color ?? "zinc"].dot}
+              nodeColor={miniMapNodeColor}
               className="!bg-card"
             />
           </ReactFlow>
@@ -815,7 +848,7 @@ function Editor({ file }: { file?: FileBinding }) {
               {/* Render panels without TabsContent so chat state survives tab switches. */}
               <div className="min-h-0 flex-1 overflow-hidden">
                 <div className={cn("h-full", tab !== "assistant" && "hidden")}>
-                  <AssistantPanel getModel={() => model} onApply={(m) => applyModel(m)} />
+                  <AssistantPanel getModel={getModel} onApply={applyModel} />
                 </div>
                 <div className={cn("h-full overflow-y-auto", tab !== "inspector" && "hidden")}>
                   <Inspector
@@ -834,7 +867,7 @@ function Editor({ file }: { file?: FileBinding }) {
                   />
                 </div>
                 <div className={cn("h-full", tab !== "export" && "hidden")}>
-                  <ExportPanel model={model} />
+                  <ExportPanel model={tab === "export" ? model : EXPORT_IDLE_MODEL} active={tab === "export"} />
                 </div>
               </div>
             </Tabs>

--- a/packages/model-editor/src/model-editor-view.tsx
+++ b/packages/model-editor/src/model-editor-view.tsx
@@ -250,8 +250,11 @@ function Editor({ file }: { file?: FileBinding }) {
       if (!file?.onSave || saving) return;
       setSaving(true);
       try {
-        await file.onSave(toPrisma(modelRef.current, { metadata: embed }));
-        setDirty(false);
+        // Snapshot what we're saving; if the user edits during the in-flight save,
+        // `modelRef.current` moves on and we must keep `dirty` so those edits persist.
+        const saved = modelRef.current;
+        await file.onSave(toPrisma(saved, { metadata: embed }));
+        if (modelRef.current === saved) setDirty(false);
       } catch {
         toast.error("Couldn't save the file");
       } finally {

--- a/packages/model-editor/src/model-editor.css
+++ b/packages/model-editor/src/model-editor.css
@@ -1,0 +1,25 @@
+/* Model Editor canvas tuning, layered on top of @xyflow/react's stylesheet. */
+
+/*
+ * Promote each node to its own compositor layer. React Flow ships no `will-change`,
+ * so every node and edge paints into the single viewport layer — dragging one node
+ * then repaints the whole canvas every frame (measured ~4M px² per frame at 25
+ * nodes), which shows up as flicker on large graphs. With each node on its own
+ * layer, a drag re-composites instead of repainting. Scoped to nodes (not the
+ * viewport) so panning/zooming is unaffected.
+ */
+.react-flow__node {
+  will-change: transform;
+}
+
+/*
+ * While a node is being dragged, pin the whole document to the `grabbing` cursor.
+ * Our node cards set `cursor: pointer`, and when the pointer briefly outpaces the
+ * dragged node it sits over the pane (default arrow) — so without this the cursor
+ * flickers between the arrow/pointer and the grab hand mid-drag. The class is
+ * toggled on <body> via React Flow's onNodeDragStart/Stop.
+ */
+body.canopy-node-dragging,
+body.canopy-node-dragging * {
+  cursor: grabbing !important;
+}

--- a/packages/model-editor/src/node-drag-cursor.ts
+++ b/packages/model-editor/src/node-drag-cursor.ts
@@ -1,0 +1,13 @@
+// Pins the document cursor to `grabbing` for the duration of a node drag, so it
+// doesn't flicker to the arrow/pointer when the pointer outpaces the dragged node
+// (the matching CSS lives in model-editor.css). Pass these straight to a ReactFlow's
+// `onNodeDragStart` / `onNodeDragStop`; their identities are stable across renders.
+const CLASS = "canopy-node-dragging";
+
+export const onNodeDragStart = (): void => {
+  document.body.classList.add(CLASS);
+};
+
+export const onNodeDragStop = (): void => {
+  document.body.classList.remove(CLASS);
+};

--- a/packages/model-editor/src/sample-project.ts
+++ b/packages/model-editor/src/sample-project.ts
@@ -1,6 +1,6 @@
 // The canonical "Pet Store" sample project — one coherent contract projected across
 // every layer the editor understands, so opening `main.tsp` populates all of the
-// Entities · Endpoints · Channels · Flows · Source tabs and each item cross-links to
+// Entities · Endpoints · Events · Flows · Source tabs and each item cross-links to
 // what references it elsewhere. Shared by the VS Code extension's "Create Sample
 // Project" command and the standalone demo's "Try a sample", so the two never drift.
 //

--- a/packages/model-editor/src/sample-project.ts
+++ b/packages/model-editor/src/sample-project.ts
@@ -1,0 +1,349 @@
+// The canonical "Pet Store" sample project — one coherent contract projected across
+// every layer the editor understands, so opening `main.tsp` populates all of the
+// Entities · Endpoints · Channels · Flows · Source tabs and each item cross-links to
+// what references it elsewhere. Shared by the VS Code extension's "Create Sample
+// Project" command and the standalone demo's "Try a sample", so the two never drift.
+//
+// The `openapi.yaml` is what the contract would emit; the Arazzo workflow resolves
+// its `sourceDescriptions` to it. Message payloads in the AsyncAPI doc `$ref` schemas
+// named like the TypeSpec models, and channels carry an `x-operationId` that binds
+// them to an HTTP endpoint — so the whole thing parses with zero diagnostics.
+
+export interface SampleFile {
+  name: string;
+  content: string;
+}
+
+const PRISMA: SampleFile = {
+  name: "schema.prisma",
+  content: `// Sample Prisma schema — open in the Canopy Model Editor to edit it visually.
+// Drag entities, draw relations, then export to SQL / JSON Schema / Mermaid.
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Owner {
+  id        String   @id @default(cuid())
+  name      String
+  email     String   @unique
+  pets      Pet[]
+  createdAt DateTime @default(now())
+}
+
+model Pet {
+  id        String   @id @default(cuid())
+  name      String
+  status    String   @default("available")
+  owner     Owner?   @relation(fields: [ownerId], references: [id])
+  ownerId   String?
+  visits    Visit[]
+  createdAt DateTime @default(now())
+}
+
+model Visit {
+  id     String   @id @default(cuid())
+  pet    Pet      @relation(fields: [petId], references: [id])
+  petId  String
+  date   DateTime
+  notes  String?
+}
+`,
+};
+
+const TSP: SampleFile = {
+  name: "main.tsp",
+  content: `import "@typespec/http";
+
+using TypeSpec.Http;
+
+// The contract behind every other tab: models become Entities, operations become
+// Endpoints, and the Arazzo + AsyncAPI files cross-link back to the ids declared here.
+@service(#{ title: "Pet Store" })
+namespace PetStore;
+
+/** A pet's availability. */
+enum PetStatus {
+  available,
+  pending,
+  sold,
+}
+
+/** Returned when a request fails. */
+@error
+model Error {
+  code: int32;
+  message: string;
+}
+
+/** A person who owns pets. */
+model Owner {
+  @key id: string;
+  name: string;
+  email: string;
+}
+
+/** A pet in the store. */
+model Pet {
+  @key id: string;
+  name: string;
+  status: PetStatus;
+  /** The owner this pet belongs to. */
+  owner: Owner;
+}
+
+/** A vet visit booked for a pet. */
+model Visit {
+  @key id: string;
+  pet: Pet;
+  date: utcDateTime;
+  notes?: string;
+}
+
+/** Request body to register an owner. */
+model CreateOwner {
+  name: string;
+  email: string;
+}
+
+/** Request body to add a pet. */
+model CreatePet {
+  name: string;
+  status: PetStatus;
+  ownerId: string;
+}
+
+/** Request body to book a visit. */
+model BookVisit {
+  petId: string;
+  date: utcDateTime;
+  notes?: string;
+}
+
+@route("/owners")
+@tag("owners")
+interface Owners {
+  @get @operationId("listOwners") list(): Owner[] | Error;
+  @get @operationId("getOwner") read(@path id: string): Owner | Error;
+  @post @operationId("createOwner") create(@body owner: CreateOwner): {
+    @statusCode statusCode: 201;
+    @body created: Owner;
+  } | Error;
+}
+
+@route("/pets")
+@tag("pets")
+interface Pets {
+  @get @operationId("listPets") list(@query status?: PetStatus): Pet[] | Error;
+  @get @operationId("getPet") read(@path id: string): Pet | Error;
+  @post @operationId("createPet") create(@body pet: CreatePet): {
+    @statusCode statusCode: 201;
+    @body created: Pet;
+  } | Error;
+  @patch @operationId("updatePetStatus") updateStatus(@path id: string, @body status: PetStatus): Pet | Error;
+}
+
+@route("/visits")
+@tag("visits")
+interface Visits {
+  @post @operationId("bookVisit") book(@body visit: BookVisit): {
+    @statusCode statusCode: 201;
+    @body created: Visit;
+  } | Error;
+  @get @operationId("listVisits") list(@query petId: string): Visit[] | Error;
+}
+`,
+};
+
+const OPENAPI: SampleFile = {
+  name: "openapi.yaml",
+  content: `# The OpenAPI your .tsp would emit. The Arazzo workflow points its
+# sourceDescriptions here, and the editor resolves that link by file name.
+openapi: 3.0.0
+info:
+  title: Pet Store
+  version: 1.0.0
+paths:
+  /owners:
+    get: { operationId: listOwners, responses: { '200': { description: ok } } }
+    post: { operationId: createOwner, responses: { '201': { description: created } } }
+  /owners/{id}:
+    get: { operationId: getOwner, responses: { '200': { description: ok } } }
+  /pets:
+    get: { operationId: listPets, responses: { '200': { description: ok } } }
+    post: { operationId: createPet, responses: { '201': { description: created } } }
+  /pets/{id}:
+    get: { operationId: getPet, responses: { '200': { description: ok } } }
+    patch: { operationId: updatePetStatus, responses: { '200': { description: ok } } }
+  /visits:
+    get: { operationId: listVisits, responses: { '200': { description: ok } } }
+    post: { operationId: bookVisit, responses: { '201': { description: created } } }
+components:
+  schemas:
+    Owner: { type: object }
+    Pet: { type: object }
+    Visit: { type: object }
+`,
+};
+
+const ARAZZO: SampleFile = {
+  name: "workflow.arazzo.yaml",
+  content: `arazzo: 1.0.1
+info:
+  title: Pet Store workflows
+  version: 1.0.0
+# x-typespec-source links these workflows back to the TypeSpec contract so the editor
+# can trace steps -> endpoints -> entities across the .tsp and .arazzo files.
+x-typespec-source: ./main.tsp
+sourceDescriptions:
+  - name: api
+    url: ./openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: onboardCustomer
+    summary: Register an owner, add their pet, and book its first visit.
+    x-tags: [owners, pets, visits]
+    steps:
+      - stepId: createOwner
+        description: Register the new owner.
+        operationId: createOwner
+        successCriteria:
+          - condition: $statusCode == 201
+        outputs:
+          ownerId: $response.body#/id
+      - stepId: createPet
+        description: Add a pet for that owner.
+        operationId: createPet
+        parameters:
+          - name: ownerId
+            in: body
+            value: $steps.createOwner.outputs.ownerId
+        successCriteria:
+          - condition: $statusCode == 201
+        outputs:
+          petId: $response.body#/id
+      - stepId: bookVisit
+        description: Book the pet's first vet visit.
+        operationId: bookVisit
+        parameters:
+          - name: petId
+            in: body
+            value: $steps.createPet.outputs.petId
+        successCriteria:
+          - condition: $statusCode == 201
+        outputs:
+          visitId: $response.body#/id
+    outputs:
+      visitId: $steps.bookVisit.outputs.visitId
+  - workflowId: findAndBook
+    summary: Find an available pet and book a visit for it.
+    x-tags: [pets, visits]
+    steps:
+      - stepId: listPets
+        description: List available pets.
+        operationId: listPets
+        successCriteria:
+          - condition: $statusCode == 200
+        outputs:
+          pets: $response.body
+      - stepId: bookVisit
+        description: Book a visit for the first pet.
+        operationId: bookVisit
+        parameters:
+          - name: petId
+            in: body
+            value: $steps.listPets.outputs.pets[0].id
+        successCriteria:
+          - condition: $statusCode == 201
+        outputs:
+          visitId: $response.body#/id
+    outputs:
+      visitId: $steps.bookVisit.outputs.visitId
+`,
+};
+
+const ASYNCAPI: SampleFile = {
+  name: "events.asyncapi.yaml",
+  content: `asyncapi: 3.0.0
+info:
+  title: Pet Store events
+  version: 1.0.0
+# Each message payload $refs a schema named like a .tsp model, so the editor links
+# the channel to that entity; x-operationId binds a channel to an HTTP endpoint.
+servers:
+  live:
+    host: petstore.example.com
+    protocol: sse
+channels:
+  petEvents:
+    address: /pets/events
+    servers:
+      - $ref: '#/servers/live'
+    messages:
+      petStatusChanged:
+        $ref: '#/components/messages/PetStatusChanged'
+      petCreated:
+        $ref: '#/components/messages/PetCreated'
+  visitEvents:
+    address: /visits/events
+    servers:
+      - $ref: '#/servers/live'
+    messages:
+      visitBooked:
+        $ref: '#/components/messages/VisitBooked'
+operations:
+  receivePetStatusChanged:
+    action: receive
+    channel:
+      $ref: '#/channels/petEvents'
+    messages:
+      - $ref: '#/channels/petEvents/messages/petStatusChanged'
+    x-operationId: getPet
+  receivePetCreated:
+    action: receive
+    channel:
+      $ref: '#/channels/petEvents'
+    messages:
+      - $ref: '#/channels/petEvents/messages/petCreated'
+  receiveVisitBooked:
+    action: receive
+    channel:
+      $ref: '#/channels/visitEvents'
+    messages:
+      - $ref: '#/channels/visitEvents/messages/visitBooked'
+    x-operationId: bookVisit
+components:
+  messages:
+    PetStatusChanged:
+      summary: A pet's availability status changed.
+      payload:
+        $ref: '#/components/schemas/Pet'
+    PetCreated:
+      summary: A new pet was added.
+      payload:
+        $ref: '#/components/schemas/Pet'
+    VisitBooked:
+      summary: A visit was booked for a pet.
+      payload:
+        $ref: '#/components/schemas/Visit'
+  schemas:
+    Pet:
+      type: object
+    Visit:
+      type: object
+`,
+};
+
+/**
+ * The Pet Store sample, in load order. `main.tsp` is the contract everything else
+ * links to, so hosts should open it first.
+ */
+export const SAMPLE_PROJECT: SampleFile[] = [PRISMA, TSP, OPENAPI, ARAZZO, ASYNCAPI];
+
+/** The file a host should open by default — the contract that drives every tab. */
+export const SAMPLE_ENTRYPOINT = "main.tsp";

--- a/packages/model-editor/src/spec/asyncapi.ts
+++ b/packages/model-editor/src/spec/asyncapi.ts
@@ -1,0 +1,194 @@
+// Parse an AsyncAPI document (YAML/JSON) into the events layer of the project graph.
+// We read structure only — channels, their send/receive operations, and the message
+// payloads that flow over them. Message payloads referencing a named schema become
+// the link back to entities; an `x-operationId` extension (or a channel address that
+// matches an endpoint route) becomes the best-effort link to an HTTP endpoint.
+//
+// We target AsyncAPI 3.0 (top-level `channels` + `operations`, messages by ref) but
+// degrade gracefully to 2.x, where operations live inline under each channel as
+// `publish`/`subscribe`. The 2.x→3.x action mapping follows the application's point
+// of view: `subscribe` ⇒ the app receives, `publish` ⇒ the app sends.
+
+import yaml from "js-yaml";
+import type { Diagnostic, SpecChannel, SpecChannelOp, SpecMessage } from "./graph-types";
+
+export interface AsyncApiResult {
+  isAsyncApi: boolean;
+  channels: SpecChannel[];
+  diagnostics: Diagnostic[];
+}
+
+const empty: AsyncApiResult = { isAsyncApi: false, channels: [], diagnostics: [] };
+
+const isObj = (v: unknown): v is Record<string, any> => !!v && typeof v === "object" && !Array.isArray(v);
+
+/** The last path segment of a local `$ref` (`#/components/schemas/Pet` ⇒ `Pet`). */
+const refName = (ref: unknown): string | undefined =>
+  typeof ref === "string" && ref.startsWith("#/") ? decodeURIComponent(ref.split("/").pop() ?? "") || undefined : undefined;
+
+/** Resolve a local `$ref` to the node it points at, within this document. */
+function resolveRef(doc: Record<string, any>, ref: string): any {
+  if (!ref.startsWith("#/")) return undefined;
+  let node: any = doc;
+  for (const raw of ref.slice(2).split("/")) {
+    const key = raw.replace(/~1/g, "/").replace(/~0/g, "~");
+    if (!isObj(node) && !Array.isArray(node)) return undefined;
+    node = (node as Record<string, any>)[key];
+  }
+  return node;
+}
+
+/** Follow a `{ $ref }` wrapper one hop (or return the node as-is). */
+const deref = (doc: Record<string, any>, node: any): any =>
+  isObj(node) && typeof node.$ref === "string" ? resolveRef(doc, node.$ref) : node;
+
+const readTags = (node: any): string[] | undefined => {
+  const raw = Array.isArray(node?.tags) ? node.tags : Array.isArray(node?.["x-tags"]) ? node["x-tags"] : [];
+  const tags = raw
+    .map((t: unknown) => (typeof t === "string" ? t : isObj(t) && typeof t.name === "string" ? t.name : undefined))
+    .filter((t: unknown): t is string => typeof t === "string");
+  return tags.length ? tags : undefined;
+};
+
+/** Read a message node (resolving a `$ref`) into a normalised SpecMessage. */
+function readMessage(doc: Record<string, any>, name: string, node: any): SpecMessage {
+  const m = deref(doc, node) ?? {};
+  const payload = m.payload;
+  const payloadRef = refName(payload?.$ref) ?? refName(m.payload?.$ref);
+  return {
+    name,
+    title: typeof m.title === "string" ? m.title : undefined,
+    payloadRef,
+    payloadType: !payloadRef && isObj(payload) ? (typeof payload.type === "string" ? payload.type : "object") : undefined,
+    contentType: typeof m.contentType === "string" ? m.contentType : undefined,
+    doc: typeof m.summary === "string" ? m.summary : typeof m.description === "string" ? m.description : undefined,
+  };
+}
+
+/** A message name keyed off its `$ref`, a channel-local key, or its own `name`/`messageId`. */
+const messageKey = (doc: Record<string, any>, fallbackKey: string, node: any): string => {
+  const byRef = refName(node?.$ref);
+  if (byRef) return byRef;
+  const m = deref(doc, node) ?? {};
+  return (typeof m.messageId === "string" && m.messageId) || (typeof m.name === "string" && m.name) || fallbackKey;
+};
+
+export function parseAsyncApi(text: string, fileName: string): AsyncApiResult {
+  let doc: unknown;
+  try {
+    doc = yaml.load(text);
+  } catch (e) {
+    return { ...empty, diagnostics: [{ severity: "error", layer: "asyncapi", message: `Invalid YAML in ${fileName}: ${e instanceof Error ? e.message : "parse error"}`, file: fileName }] };
+  }
+  if (!isObj(doc) || !("asyncapi" in doc)) return empty;
+  const d = doc;
+  const diagnostics: Diagnostic[] = [];
+  const major = parseInt(String(d.asyncapi), 10) || 0;
+
+  // server name → protocol, so a channel can report what it speaks.
+  const serverProtocol = new Map<string, string>();
+  for (const [name, srv] of Object.entries(isObj(d.servers) ? d.servers : {})) {
+    if (isObj(srv) && typeof srv.protocol === "string") serverProtocol.set(name, srv.protocol);
+  }
+  const allProtocols = [...new Set(serverProtocol.values())];
+
+  const channels: SpecChannel[] = [];
+  const channelByName = new Map<string, SpecChannel>();
+
+  for (const [key, raw] of Object.entries(isObj(d.channels) ? d.channels : {})) {
+    const ch = deref(d, raw);
+    if (!isObj(ch)) continue;
+
+    // Protocols: resolve the channel's `servers` refs, else fall back to every server.
+    const serverRefs = Array.isArray(ch.servers) ? ch.servers : [];
+    const protocols = serverRefs.length
+      ? [...new Set(serverRefs.map((s: any) => serverProtocol.get(refName(s?.$ref) ?? "")).filter((p: unknown): p is string => !!p))]
+      : allProtocols;
+
+    // Messages: 3.x declares them under `channel.messages`; 2.x inlines a single
+    // `message` on each publish/subscribe (collected with the operations below).
+    const messages: SpecMessage[] = [];
+    const messageByKey = new Map<string, SpecMessage>();
+    const addMessage = (name: string, node: any) => {
+      if (messageByKey.has(name)) return messageByKey.get(name)!;
+      const msg = readMessage(d, name, node);
+      messages.push(msg);
+      messageByKey.set(name, msg);
+      return msg;
+    };
+    // Name a channel message by its local map key — that's the identifier 3.x
+    // operations reference (`#/channels/<c>/messages/<key>`), so the two line up.
+    for (const [mKey, mNode] of Object.entries(isObj(ch.messages) ? ch.messages : {})) {
+      addMessage(mKey, mNode);
+    }
+
+    const channel: SpecChannel = {
+      id: key,
+      name: key,
+      address: typeof ch.address === "string" ? ch.address : key,
+      doc: typeof ch.summary === "string" ? ch.summary : typeof ch.description === "string" ? ch.description : undefined,
+      protocols: protocols.length ? protocols : undefined,
+      operations: [],
+      messages,
+      refModels: [],
+      operationIdHint: typeof ch["x-operationId"] === "string" ? ch["x-operationId"] : undefined,
+      tags: readTags(ch),
+      file: fileName,
+    };
+
+    // 2.x: operations are inline `publish`/`subscribe` blocks on the channel.
+    if (major < 3) {
+      for (const [verb, action] of [["subscribe", "receive"], ["publish", "send"]] as const) {
+        const op = ch[verb];
+        if (!isObj(op)) continue;
+        const msgName = op.message ? addMessage(messageKey(d, `${key}.${verb}`, op.message), op.message).name : undefined;
+        if (!channel.operationIdHint && typeof op["x-operationId"] === "string") channel.operationIdHint = op["x-operationId"];
+        channel.operations.push({
+          id: typeof op.operationId === "string" ? op.operationId : `${key}.${verb}`,
+          action,
+          doc: typeof op.summary === "string" ? op.summary : typeof op.description === "string" ? op.description : undefined,
+          messages: msgName ? [msgName] : [],
+        } satisfies SpecChannelOp);
+      }
+    }
+
+    channels.push(channel);
+    channelByName.set(key, channel);
+  }
+
+  // 3.x: operations are a top-level map, each pointing at a channel + its messages.
+  if (major >= 3) {
+    for (const [opId, raw] of Object.entries(isObj(d.operations) ? d.operations : {})) {
+      const op = deref(d, raw);
+      if (!isObj(op)) continue;
+      // `channel: { $ref: '#/channels/<key>' }` — recover the channel key.
+      const chName = refName(op.channel?.$ref);
+      const channel = chName ? channelByName.get(chName) : undefined;
+      if (!channel) continue;
+      const msgNodes = Array.isArray(op.messages) ? op.messages : [];
+      const msgNames = msgNodes
+        .map((mn: any) => {
+          // 3.x operation messages ref the channel's message: #/channels/<c>/messages/<key>
+          const segs = typeof mn?.$ref === "string" ? mn.$ref.split("/") : [];
+          const localKey = segs.length ? decodeURIComponent(segs[segs.length - 1]!) : undefined;
+          const existing = channel.messages.find((m) => m.name === localKey);
+          return existing ? existing.name : localKey;
+        })
+        .filter((n: unknown): n is string => typeof n === "string");
+      if (!channel.operationIdHint && typeof op["x-operationId"] === "string") channel.operationIdHint = op["x-operationId"];
+      channel.operations.push({
+        id: opId,
+        action: op.action === "send" ? "send" : "receive",
+        doc: typeof op.summary === "string" ? op.summary : typeof op.description === "string" ? op.description : undefined,
+        messages: msgNames,
+      } satisfies SpecChannelOp);
+    }
+  }
+
+  // Roll each channel's payload refs up to its `refModels` (de-duplicated).
+  for (const channel of channels) {
+    channel.refModels = [...new Set(channel.messages.map((m) => m.payloadRef).filter((r): r is string => !!r))];
+  }
+
+  return { isAsyncApi: true, channels, diagnostics };
+}

--- a/packages/model-editor/src/spec/asyncapi.ts
+++ b/packages/model-editor/src/spec/asyncapi.ts
@@ -78,7 +78,9 @@ export function parseAsyncApi(text: string, fileName: string): AsyncApiResult {
   try {
     doc = yaml.load(text);
   } catch (e) {
-    return { ...empty, diagnostics: [{ severity: "error", layer: "asyncapi", message: `Invalid YAML in ${fileName}: ${e instanceof Error ? e.message : "parse error"}`, file: fileName }] };
+    // Flag as AsyncAPI so the graph builder keeps these diagnostics (it skips results
+    // where `isAsyncApi` is false) and the parse error reaches the UI.
+    return { ...empty, isAsyncApi: true, diagnostics: [{ severity: "error", layer: "asyncapi", message: `Invalid YAML in ${fileName}: ${e instanceof Error ? e.message : "parse error"}`, file: fileName }] };
   }
   if (!isObj(doc) || !("asyncapi" in doc)) return empty;
   const d = doc;

--- a/packages/model-editor/src/spec/build-graph.ts
+++ b/packages/model-editor/src/spec/build-graph.ts
@@ -5,13 +5,21 @@
 // that no longer exist.
 
 import { parseArazzo } from "./arazzo";
+import { parseAsyncApi } from "./asyncapi";
 import type { DiscoveredFiles } from "./discover";
 import { emptySidecar, parseSidecar } from "./layout-sidecar";
 import { parseOpenApi } from "./openapi";
 import { compileTypeSpec } from "./typespec";
-import { type Diagnostic, type ProjectGraph, type SourceFile, type SpecFlow, type SpecModel, type SpecSource } from "./graph-types";
+import { type Diagnostic, type ProjectGraph, type SourceFile, type SpecChannel, type SpecEndpoint, type SpecFlow, type SpecModel, type SpecSource } from "./graph-types";
 
 const basename = (p: string) => p.replace(/[#?].*$/, "").split("/").pop()!.trim();
+
+/** Compare two HTTP routes ignoring query strings and trailing slashes. */
+const sameRoute = (a?: string, b?: string) => {
+  if (!a || !b) return false;
+  const norm = (s: string) => s.replace(/[?#].*$/, "").replace(/\/+$/, "") || "/";
+  return norm(a) === norm(b);
+};
 
 /**
  * Tag each model as a persisted `entity` or a transient `dto`. An entity has identity
@@ -95,23 +103,70 @@ export async function buildProjectGraph(files: DiscoveredFiles): Promise<Project
     }
   }
 
+  // ── Events: parse every AsyncAPI doc, then link it to the contract ──
+  // Payload refs and the optional `x-operationId` are short names; resolve them to the
+  // model ids / endpoints the rest of the graph keys on (mirroring TypeSpec's pass).
+  const modelIdByName = new Map<string, string>();
+  for (const m of models) {
+    modelIdByName.set(m.id, m.id);
+    if (!modelIdByName.has(m.name)) modelIdByName.set(m.name, m.id);
+  }
+  const resolveModel = (name: string) => modelIdByName.get(name) ?? modelIdByName.get(name.split(".").pop()!);
+  const endpointByOp = new Map<string, SpecEndpoint>(endpoints.map((e) => [e.operationId, e]));
+
+  const channels: SpecChannel[] = [];
+  for (const f of files.asyncapi) {
+    const res = parseAsyncApi(f.text, f.name);
+    if (!res.isAsyncApi) continue;
+    diagnostics.push(...res.diagnostics);
+    for (const ch of res.channels) {
+      // Rewrite each payload ref from its schema name to the resolved model id so the
+      // UI can navigate to the entity; leave it as the raw name when no model matches.
+      for (const msg of ch.messages) if (msg.payloadRef) msg.payloadRef = resolveModel(msg.payloadRef) ?? msg.payloadRef;
+      ch.refModels = [...new Set(ch.messages.map((m) => m.payloadRef).filter((r): r is string => !!r && modelIdByName.has(r)))];
+
+      // Endpoint link: an explicit `x-operationId` wins; else match the address to a route.
+      if (ch.operationIdHint) {
+        const ep = endpointByOp.get(ch.operationIdHint);
+        if (ep) ch.endpointId = ep.id;
+        else {
+          diagnostics.push({
+            severity: "warning",
+            layer: "link",
+            message: `Channel "${ch.name}" binds x-operationId "${ch.operationIdHint}", which no operation provides.`,
+            target: { kind: "channel", id: ch.id },
+            file: f.name,
+          });
+        }
+      }
+      if (!ch.endpointId) {
+        const match = endpoints.find((e) => sameRoute(e.route, ch.address));
+        if (match) ch.endpointId = match.id;
+      }
+      channels.push(ch);
+    }
+  }
+
   const sourceFiles: SourceFile[] = [
     ...files.tsp.map((f) => ({ id: f.id, name: f.name, kind: "tsp" as const, text: f.text })),
     ...files.openapi.map((f) => ({ id: f.id, name: f.name, kind: "openapi" as const, text: f.text })),
     ...files.arazzo.map((f) => ({ id: f.id, name: f.name, kind: "arazzo" as const, text: f.text })),
+    ...files.asyncapi.map((f) => ({ id: f.id, name: f.name, kind: "asyncapi" as const, text: f.text })),
   ];
 
-  const empty = models.length === 0 && endpoints.length === 0 && flows.length === 0;
+  const empty = models.length === 0 && endpoints.length === 0 && flows.length === 0 && channels.length === 0;
   return {
     models,
     endpoints,
     flows,
+    channels,
     sources,
     diagnostics,
     files: {
       tsp: files.tsp.map((f) => f.name),
       openapi: files.openapi.map((f) => f.name),
       arazzo: files.arazzo.map((f) => f.name),
+      asyncapi: files.asyncapi.map((f) => f.name),
     },
     sourceFiles,
     layout: files.layout ? parseSidecar(files.layout.text) : emptySidecar(),

--- a/packages/model-editor/src/spec/channels-tab.tsx
+++ b/packages/model-editor/src/spec/channels-tab.tsx
@@ -1,0 +1,132 @@
+import { useMemo } from "react";
+import { Icon } from "@canopy/ui";
+import { cn } from "@canopy/ui";
+import type { SpecChannel } from "./graph-types";
+import type { SpecViewProps } from "./view-types";
+
+const ACTION_TONE = {
+  send: "bg-emerald-500/10 text-emerald-600",
+  receive: "bg-sky-500/10 text-sky-600",
+} as const;
+
+/** The Channels list shares the view's tag filter with the other tabs. */
+export interface ChannelsTabProps extends SpecViewProps {
+  /** Active tag include-filter (empty ⇒ show all). */
+  tagFilter: string[];
+}
+
+/** Events (AsyncAPI channels) as a list grouped by protocol, linked to entities + endpoints. */
+export function ChannelsTab({ graph, index, selection, related, onSelect, onNavigate, tagFilter }: ChannelsTabProps) {
+  const errored = useMemo(
+    () => new Set(graph.diagnostics.filter((d) => d.target?.kind === "channel").map((d) => d.target!.id)),
+    [graph.diagnostics],
+  );
+  const groups = useMemo(() => {
+    const map = new Map<string, SpecChannel[]>();
+    for (const c of graph.channels) {
+      if (tagFilter.length && !c.tags?.some((t) => tagFilter.includes(t))) continue;
+      const key = c.protocols?.length ? c.protocols.join(", ") : "Channels";
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(c);
+    }
+    return [...map.entries()];
+  }, [graph.channels, tagFilter]);
+
+  if (!graph.channels.length) {
+    return <div className="grid h-full place-items-center text-sm text-muted-foreground">No AsyncAPI channels found in this project.</div>;
+  }
+  if (!groups.length) {
+    return <div className="grid h-full place-items-center text-sm text-muted-foreground">No channels match the active tag filter.</div>;
+  }
+
+  return (
+    <div className="h-full overflow-y-auto px-4 py-4">
+      {groups.map(([group, channels]) => (
+        <div key={group} className="mb-5">
+          <div className="mb-2 flex items-center gap-1.5 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground">
+            <Icon name="radio" size={13} /> {group}
+            <span className="font-mono text-[10px]">({channels.length})</span>
+          </div>
+          <div className="overflow-hidden rounded-lg border">
+            {channels.map((c) => {
+              const active = selection?.kind === "channel" && selection.id === c.id;
+              const dim = related.channels.size > 0 && !related.channels.has(c.id);
+              const endpoint = index.endpointForChannel(c);
+              const models = index.modelsForChannel(c.id);
+              return (
+                <div key={c.id} className={cn("border-b last:border-b-0 transition", dim && "opacity-40", active && "bg-accent/50")}>
+                  <button onClick={() => onSelect({ kind: "channel", id: c.id })} className="flex w-full items-center gap-2.5 px-3 py-2 text-left hover:bg-accent/40">
+                    <div className="flex w-14 shrink-0 gap-1">
+                      {c.operations.length ? c.operations.map((op) => (
+                        <span key={op.id} title={`${op.action} · ${op.id}`} className={cn("rounded px-1 py-0.5", ACTION_TONE[op.action])}>
+                          <Icon name={op.action === "send" ? "send" : "inbox"} size={11} />
+                        </span>
+                      )) : <span className="rounded bg-muted px-1.5 py-0.5 text-center font-mono text-[10px] text-muted-foreground">ch</span>}
+                    </div>
+                    <span className="shrink-0 font-mono text-[13px] font-semibold">{c.name}</span>
+                    {c.address && c.address !== c.name && <span className="truncate font-mono text-[11px] text-muted-foreground">{c.address}</span>}
+                    {c.tags?.map((t) => (
+                      <span key={t} className="shrink-0 rounded-full bg-accent px-1.5 py-0.5 font-mono text-[9px] text-accent-foreground">#{t}</span>
+                    ))}
+                    {errored.has(c.id) && <Icon name="alert-triangle" size={13} className="ml-auto shrink-0 text-destructive" />}
+                    {!errored.has(c.id) && endpoint && (
+                      <span className="ml-auto flex shrink-0 items-center gap-1 font-mono text-[10px] text-muted-foreground" title={`Linked to endpoint ${endpoint.operationId}`}>
+                        <Icon name="globe" size={11} /> {endpoint.operationId}
+                      </span>
+                    )}
+                  </button>
+                  {active && (
+                    <div className="space-y-2 border-t bg-muted/30 px-3 py-2.5 text-[12px]">
+                      {c.doc && <p className="text-muted-foreground">{c.doc}</p>}
+                      {!!c.messages.length && (
+                        <div className="space-y-1">
+                          <span className="text-[11px] text-muted-foreground">Messages:</span>
+                          <ul className="space-y-1">
+                            {c.messages.map((m) => {
+                              const model = m.payloadRef ? index.modelById.get(m.payloadRef) : undefined;
+                              return (
+                                <li key={m.name} className="flex items-center gap-2">
+                                  <Icon name="bell" size={11} className="shrink-0 text-muted-foreground" />
+                                  <span className="font-mono text-[11px]">{m.name}</span>
+                                  {model ? (
+                                    <button onClick={() => onNavigate({ kind: "entity", id: model.id })} className="ml-auto truncate rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[11px] text-primary hover:underline">
+                                      {model.name}
+                                    </button>
+                                  ) : (
+                                    (m.payloadRef || m.payloadType) && <span className="ml-auto truncate font-mono text-[11px] text-muted-foreground">{m.payloadRef ?? m.payloadType}</span>
+                                  )}
+                                </li>
+                              );
+                            })}
+                          </ul>
+                        </div>
+                      )}
+                      {!!models.length && (
+                        <div className="flex flex-wrap items-center gap-1.5">
+                          <span className="text-[11px] text-muted-foreground">Entities:</span>
+                          {models.map((m) => (
+                            <button key={m.id} onClick={() => onNavigate({ kind: "entity", id: m.id })} className={cn("rounded px-1.5 py-0.5 font-mono text-[11px] hover:underline", m.isError ? "bg-destructive/10 text-destructive" : "bg-primary/10 text-primary")}>
+                              {m.name}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                      {endpoint && (
+                        <div className="flex flex-wrap items-center gap-1.5">
+                          <span className="text-[11px] text-muted-foreground">Endpoint:</span>
+                          <button onClick={() => onNavigate({ kind: "endpoint", id: endpoint.id })} className="flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] hover:underline">
+                            <Icon name="globe" size={10} /> {endpoint.operationId}
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/model-editor/src/spec/discover.ts
+++ b/packages/model-editor/src/spec/discover.ts
@@ -60,7 +60,7 @@ export async function discoverProject(
   else if (isAsyncApi(opened.name)) asyncapi.set(opened.name, { id: opened.id, name: opened.name, path: opened.path, text: opened.text });
 
   const reads = provider.siblings
-    .filter((ref) => isTsp(ref.name) || isArazzo(ref.name) || isYamlOrJson(ref.name))
+    .filter((ref) => isTsp(ref.name) || isArazzo(ref.name) || isAsyncApi(ref.name) || isYamlOrJson(ref.name))
     .filter((ref) => ref.name !== opened.name) // opened file already seeded
     .map(async (ref) => {
       try {
@@ -77,8 +77,9 @@ export async function discoverProject(
     if (ref.name === SIDECAR_NAME) layout = toTextFile(ref, text);
     else if (isTsp(ref.name)) tsp.set(ref.name, toTextFile(ref, text));
     else if (isArazzo(ref.name)) arazzo.set(ref.name, toTextFile(ref, text));
-    // AsyncAPI is also YAML/JSON, so sniff it before falling through to OpenAPI.
-    else if (isYamlOrJson(ref.name) && (looksLikeAsyncApi(ref.name) || sniffAsyncApi(text))) asyncapi.set(ref.name, toTextFile(ref, text));
+    // A bare `.asyncapi` file (or an `.asyncapi.{yaml,json}`); AsyncAPI is also
+    // YAML/JSON, so sniff the YAML/JSON ones before falling through to OpenAPI.
+    else if (isAsyncApi(ref.name) || (isYamlOrJson(ref.name) && (looksLikeAsyncApi(ref.name) || sniffAsyncApi(text)))) asyncapi.set(ref.name, toTextFile(ref, text));
     else if (isYamlOrJson(ref.name) && (looksLikeOpenApi(ref.name) || sniffOpenApi(text))) openapi.set(ref.name, toTextFile(ref, text));
   }
 

--- a/packages/model-editor/src/spec/discover.ts
+++ b/packages/model-editor/src/spec/discover.ts
@@ -1,5 +1,5 @@
 // File discovery: from one opened `.tsp` or `.arazzo` file, gather the whole related
-// set in the same folder so the project graph spans all three layers. We scan the
+// set in the same folder so the project graph spans every layer. We scan the
 // containing folder, classify by name, and read the relevant texts. Resolution of
 // `sourceDescriptions` urls and `import`s happens in build-graph against this set.
 //
@@ -25,15 +25,19 @@ export interface DiscoveredFiles {
   tsp: TextFile[];
   arazzo: TextFile[];
   openapi: TextFile[];
+  asyncapi: TextFile[];
   /** The `canopy.layout.json` sidecar, when present in the folder. */
   layout?: TextFile;
 }
 
 export const isTsp = (name: string) => /\.tsp$/i.test(name);
 export const isArazzo = (name: string) => /\.arazzo(\.(ya?ml|json))?$/i.test(name);
+export const isAsyncApi = (name: string) => /\.asyncapi(\.(ya?ml|json))?$/i.test(name);
 const isYamlOrJson = (name: string) => /\.(ya?ml|json)$/i.test(name);
 const looksLikeOpenApi = (name: string) => /openapi|swagger/i.test(name);
+const looksLikeAsyncApi = (name: string) => /asyncapi/i.test(name);
 const sniffOpenApi = (text: string) => /^\s*("?(openapi|swagger)"?\s*:)/m.test(text);
+const sniffAsyncApi = (text: string) => /^\s*("?asyncapi"?\s*:)/m.test(text);
 
 const toTextFile = (ref: SpecFileRef, text: string): TextFile => ({ id: ref.id, name: ref.name, path: ref.path, text });
 
@@ -48,10 +52,12 @@ export async function discoverProject(
   const tsp = new Map<string, TextFile>();
   const arazzo = new Map<string, TextFile>();
   const openapi = new Map<string, TextFile>();
+  const asyncapi = new Map<string, TextFile>();
 
   // Seed with the opened file so discovery works even before anything is read.
   if (isTsp(opened.name)) tsp.set(opened.name, { id: opened.id, name: opened.name, path: opened.path, text: opened.text });
   else if (isArazzo(opened.name)) arazzo.set(opened.name, { id: opened.id, name: opened.name, path: opened.path, text: opened.text });
+  else if (isAsyncApi(opened.name)) asyncapi.set(opened.name, { id: opened.id, name: opened.name, path: opened.path, text: opened.text });
 
   const reads = provider.siblings
     .filter((ref) => isTsp(ref.name) || isArazzo(ref.name) || isYamlOrJson(ref.name))
@@ -71,8 +77,10 @@ export async function discoverProject(
     if (ref.name === SIDECAR_NAME) layout = toTextFile(ref, text);
     else if (isTsp(ref.name)) tsp.set(ref.name, toTextFile(ref, text));
     else if (isArazzo(ref.name)) arazzo.set(ref.name, toTextFile(ref, text));
+    // AsyncAPI is also YAML/JSON, so sniff it before falling through to OpenAPI.
+    else if (isYamlOrJson(ref.name) && (looksLikeAsyncApi(ref.name) || sniffAsyncApi(text))) asyncapi.set(ref.name, toTextFile(ref, text));
     else if (isYamlOrJson(ref.name) && (looksLikeOpenApi(ref.name) || sniffOpenApi(text))) openapi.set(ref.name, toTextFile(ref, text));
   }
 
-  return { tsp: [...tsp.values()], arazzo: [...arazzo.values()], openapi: [...openapi.values()], layout };
+  return { tsp: [...tsp.values()], arazzo: [...arazzo.values()], openapi: [...openapi.values()], asyncapi: [...asyncapi.values()], layout };
 }

--- a/packages/model-editor/src/spec/entities-tab.tsx
+++ b/packages/model-editor/src/spec/entities-tab.tsx
@@ -237,6 +237,8 @@ function Graph({ graph, selection, related, onSelect, positions, onMove, onReset
     },
     [onMove],
   );
+  // If we unmount mid-drag (drag-stop never fires), clear the global grabbing cursor.
+  useEffect(() => () => void (dragging.current && onNodeDragStop()), []);
 
   const edges: Edge[] = useMemo(() => {
     const seen = new Set<string>();

--- a/packages/model-editor/src/spec/entities-tab.tsx
+++ b/packages/model-editor/src/spec/entities-tab.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Background,
   BackgroundVariant,
@@ -9,13 +9,15 @@ import {
   Position,
   ReactFlow,
   ReactFlowProvider,
+  useNodesState,
   useReactFlow,
   type Edge,
   type Node,
-  type NodeChange,
   type NodeProps,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import "../model-editor.css";
+import { onNodeDragStart, onNodeDragStop } from "../node-drag-cursor";
 import { Icon } from "@canopy/ui";
 import { cn } from "@canopy/ui";
 import { ACCENTS, ACCENT_KEYS, type AccentKey } from "../types";
@@ -102,6 +104,23 @@ function SpecEntityNodeImpl({ data, selected }: NodeProps) {
 const SpecEntityNode = memo(SpecEntityNodeImpl);
 const nodeTypes = { specEntity: SpecEntityNode };
 
+// Shared fallback position (stable identity) for entities without a placed/auto position.
+const FALLBACK_POS = { x: 0, y: 0 };
+
+/** Card width is fixed by `w-[230px]`. */
+const ENTITY_WIDTH = 230;
+// Rough card height so dagre can pack ranks without overlap. We round each part up:
+// over-estimating only adds breathing room, while under-estimating brings overlap back.
+function estimateEntityHeight(m: SpecModel): number {
+  const header = 40;
+  const tags = m.tags?.length ? 30 : 0;
+  const body =
+    m.kind === "enum"
+      ? 20 + Math.ceil((m.enumValues?.length ?? 0) / 3) * 28
+      : Math.max(1, m.fields.length) * 30;
+  return header + tags + body;
+}
+
 function Graph({ graph, selection, related, onSelect, positions, onMove, onResetLayout, hasOverrides, showDtos, tagFilter }: EntitiesTabProps) {
   const { fitView } = useReactFlow();
   // Entities are the default view; DTOs (request/response payloads) are opt-in so the
@@ -124,41 +143,99 @@ function Graph({ graph, selection, related, onSelect, positions, onMove, onReset
 
   // Auto-layout gives the default arrangement; the active view's saved positions
   // override it per model. Drags are reported up to the shell, which stages them.
-  // Only edges between visible nodes count, so hiding DTOs doesn't strand entities.
-  const layout = useMemo(
-    () => layeredPositions(models.map((m) => ({ id: m.id, deps: m.fields.map((f) => f.ref).filter((r): r is string => !!r && visibleIds.has(r)) })), { dx: 300, dy: 200 }),
-    [models, visibleIds],
-  );
-
-  const onNodesChange = useCallback(
-    (changes: NodeChange[]) => {
-      for (const c of changes) if (c.type === "position" && c.position) onMove(c.id, c.position);
-    },
-    [onMove],
-  );
+  //
+  // Direction matters: edges are drawn source = the model holding the FK → target =
+  // the referenced model (arrowhead on the referenced one, out the right handle into
+  // the next card's left handle). For those to flow forward, the *referencing* model
+  // must sit to the LEFT of the one it points at. `layeredPositions` places an item's
+  // `deps` to its left, so we feed it reverse adjacency: a referenced model lists the
+  // models that point at it as its upstream deps. Only edges between visible nodes
+  // count, so hiding DTOs doesn't strand entities.
+  const layoutItems = useMemo(() => {
+    const upstream = new Map<string, string[]>(models.map((m) => [m.id, []]));
+    for (const m of models)
+      for (const f of m.fields)
+        if (f.ref && f.ref !== m.id && visibleIds.has(f.ref)) upstream.get(f.ref)!.push(m.id);
+    return models.map((m) => ({
+      id: m.id,
+      deps: upstream.get(m.id)!,
+      width: ENTITY_WIDTH,
+      height: estimateEntityHeight(m),
+    }));
+  }, [models, visibleIds]);
+  // ELK is async, so compute into state. We keep the previous result while a new one
+  // is in flight (rather than clearing it) so a filter toggle re-flows without a flash.
+  const [layout, setLayout] = useState<Map<string, XY>>(new Map());
+  useEffect(() => {
+    let alive = true;
+    layeredPositions(layoutItems, { width: ENTITY_WIDTH }).then((pos) => alive && setLayout(pos));
+    return () => {
+      alive = false;
+    };
+  }, [layoutItems]);
 
   const resetLayout = useCallback(() => {
     onResetLayout();
     setTimeout(() => fitView({ padding: 0.2, duration: 300 }), 40);
   }, [onResetLayout, fitView]);
 
-  const nodes: Node[] = useMemo(
-    () =>
-      models.map((m) => ({
+  // Build nodes while preserving object identity for unchanged entities: React Flow
+  // re-renders a node whenever its object reference changes, so rebuilding every node
+  // each render (e.g. on a single drag) would re-render the whole graph and flicker at
+  // scale. Reuse the prior node object whenever its inputs are referentially identical
+  // — only the dragged entity's position changes, so only it is rebuilt.
+  const nodeCache = useRef(new Map<string, { node: Node; sig: readonly unknown[] }>());
+  const targetNodes: Node[] = useMemo(() => {
+    const cache = nodeCache.current;
+    const live = new Set<string>();
+    const out = models.map((m) => {
+      live.add(m.id);
+      const position = positions[m.id] ?? layout.get(m.id) ?? FALLBACK_POS;
+      const color = colorFor.get(m.id) ?? "zinc";
+      const dim = related.entities.size > 0 && !related.entities.has(m.id);
+      const isErr = errored.has(m.id);
+      const isDto = m.role === "dto";
+      const selected = selection?.kind === "entity" && selection.id === m.id;
+      const sig: readonly unknown[] = [m, position, color, dim, isErr, isDto, selected, onSelect];
+      const prev = cache.get(m.id);
+      if (prev && prev.sig.every((v, i) => v === sig[i])) return prev.node;
+      const node: Node = {
         id: m.id,
         type: "specEntity",
-        position: positions[m.id] ?? layout.get(m.id) ?? { x: 0, y: 0 },
-        data: {
-          model: m,
-          color: colorFor.get(m.id) ?? "zinc",
-          dim: related.entities.size > 0 && !related.entities.has(m.id),
-          errored: errored.has(m.id),
-          isDto: m.role === "dto",
-          onPick: (id: string) => onSelect({ kind: "entity", id }),
-        } satisfies EntityNodeData,
-        selected: selection?.kind === "entity" && selection.id === m.id,
-      })),
-    [models, layout, positions, colorFor, related, errored, selection, onSelect],
+        position,
+        data: { model: m, color, dim, errored: isErr, isDto, onPick: (id: string) => onSelect({ kind: "entity", id }) } satisfies EntityNodeData,
+        selected,
+      };
+      cache.set(m.id, { node, sig });
+      return node;
+    });
+    for (const id of cache.keys()) if (!live.has(id)) cache.delete(id);
+    return out;
+  }, [models, layout, positions, colorFor, related, errored, selection, onSelect]);
+
+  // React Flow owns node positions during a drag. We mirror `targetNodes` into its
+  // state and let `onNodesChange` apply drag deltas, committing the final position to
+  // the layout store only on drag stop. Re-deriving the nodes array from the store on
+  // every drag frame (the previous approach) handed React Flow a fresh object for the
+  // node it was dragging each frame, so it lost its measured size and flashed.
+  const [nodes, setNodes, onNodesChange] = useNodesState(targetNodes);
+  const dragging = useRef(false);
+  useEffect(() => {
+    if (dragging.current) return; // never clobber the node being moved mid-drag
+    setNodes(targetNodes);
+  }, [targetNodes, setNodes]);
+
+  const handleDragStart = useCallback(() => {
+    dragging.current = true;
+    onNodeDragStart();
+  }, []);
+  const handleDragStop = useCallback(
+    (_e: unknown, _node: Node, dragged: Node[]) => {
+      dragging.current = false;
+      onNodeDragStop();
+      for (const n of dragged) onMove(n.id, n.position);
+    },
+    [onMove],
   );
 
   const edges: Edge[] = useMemo(() => {
@@ -186,15 +263,23 @@ function Graph({ graph, selection, related, onSelect, positions, onMove, onReset
     return out;
   }, [models, visibleIds, related]);
 
+  // Re-fit once positions resolve (layout is async) and on every re-flow.
   useEffect(() => {
     const t = setTimeout(() => fitView({ padding: 0.2, duration: 300 }), 80);
     return () => clearTimeout(t);
-  }, [models, fitView]);
+  }, [layout, fitView]);
 
   if (!models.length) {
     return (
       <div className="grid h-full place-items-center text-sm text-muted-foreground">
         {graph.models.length ? "No entities — every model here is a request/response DTO. Toggle “Show DTOs”." : "No TypeSpec models found in this project."}
+      </div>
+    );
+  }
+  if (!layout.size) {
+    return (
+      <div className="grid h-full place-items-center text-muted-foreground">
+        <Icon name="refresh" size={20} className="animate-spin" />
       </div>
     );
   }
@@ -204,6 +289,8 @@ function Graph({ graph, selection, related, onSelect, positions, onMove, onReset
       edges={edges}
       nodeTypes={nodeTypes}
       onNodesChange={onNodesChange}
+      onNodeDragStart={handleDragStart}
+      onNodeDragStop={handleDragStop}
       onPaneClick={() => onSelect(null)}
       fitView
       minZoom={0.2}

--- a/packages/model-editor/src/spec/flows-tab.tsx
+++ b/packages/model-editor/src/spec/flows-tab.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Background,
   BackgroundVariant,
@@ -9,13 +9,15 @@ import {
   Position,
   ReactFlow,
   ReactFlowProvider,
+  useNodesState,
   useReactFlow,
   type Edge,
   type Node,
-  type NodeChange,
   type NodeProps,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import "../model-editor.css";
+import { onNodeDragStart, onNodeDragStop } from "../node-drag-cursor";
 import { Icon } from "@canopy/ui";
 import { cn } from "@canopy/ui";
 import { layeredPositions, type XY } from "./layout";
@@ -72,6 +74,14 @@ function StepNodeImpl({ data, selected }: NodeProps) {
 }
 const StepNode = memo(StepNodeImpl);
 
+/** Card width is fixed by `w-[210px]`. */
+const STEP_WIDTH = 210;
+// Step cards grow a row per optional detail; over-estimate so dagre never packs two
+// into the same space (see the matching note in entities-tab).
+function estimateStepHeight(s: SpecStep): number {
+  return 48 + (s.operationId ? 26 : 0) + (s.callsWorkflowId ? 26 : 0) + (s.successCriteria.length ? 24 : 0);
+}
+
 function FlowLabelImpl({ data }: NodeProps) {
   const d = data as { label: string; tags?: string[] };
   return (
@@ -87,6 +97,9 @@ function FlowLabelImpl({ data }: NodeProps) {
 const FlowLabel = memo(FlowLabelImpl);
 const nodeTypes = { step: StepNode, flowLabel: FlowLabel };
 
+// Shared fallback position (stable identity) for steps without a placed position.
+const FALLBACK_POS = { x: 0, y: 0 };
+
 function Graph({ graph, index, selection, related, onSelect, stepPositions, onMoveStep, onResetSteps, hasStepOverrides, tagFilter }: FlowsTabProps) {
   const { fitView } = useReactFlow();
   const errored = useMemo(
@@ -99,38 +112,60 @@ function Graph({ graph, index, selection, related, onSelect, stepPositions, onMo
     [graph.flows, tagFilter],
   );
 
-  const { nodes, edges } = useMemo(() => {
-    const nodes: Node[] = [];
-    const edges: Edge[] = [];
-    let yOffset = 0;
-    for (const flow of flows) {
-      const pos = layeredPositions(flow.steps.map((s) => ({ id: s.id, deps: s.dependsOn })), { dx: 290, dy: 150 });
-      const ys = [...pos.values()].map((p) => p.y);
-      const minY = ys.length ? Math.min(...ys) : 0;
-      const maxY = ys.length ? Math.max(...ys) : 0;
-      nodes.push({
-        id: `label:${flow.id}`,
-        type: "flowLabel",
-        position: { x: -200, y: yOffset },
-        data: { label: flow.workflowId, tags: flow.tags },
-        draggable: false,
-        selectable: false,
-      });
-      for (const s of flow.steps) {
-        const p = pos.get(s.id) ?? { x: 0, y: 0 };
-        nodes.push({
-          id: s.id,
-          type: "step",
-          position: stepPositions[s.id] ?? { x: p.x, y: p.y - minY + yOffset },
-          data: {
-            step: s,
-            resolvedOp: !s.operationId || !!index.endpointForStep(s),
-            dim: related.steps.size > 0 && !related.steps.has(s.id),
-            errored: errored.has(s.id),
-            onPick: (id: string) => onSelect({ kind: "step", id }),
-          } satisfies StepNodeData,
-          selected: selection?.kind === "step" && selection.id === s.id,
+  // Per-flow auto-layout + label nodes. ELK is async, so we lay every flow out in
+  // parallel, then stack them vertically. Keyed on `flows` alone (not `stepPositions`)
+  // so dragging a step doesn't re-run the layout, and the previous result is kept while
+  // a new one is in flight so a re-flow doesn't flash.
+  const [layout, setLayout] = useState<{ labelByFlow: Map<string, Node>; stepBase: Map<string, XY> }>(() => ({
+    labelByFlow: new Map(),
+    stepBase: new Map(),
+  }));
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      const perFlow = await Promise.all(
+        flows.map((flow) =>
+          layeredPositions(
+            flow.steps.map((s) => ({ id: s.id, deps: s.dependsOn, width: STEP_WIDTH, height: estimateStepHeight(s) })),
+            { width: STEP_WIDTH },
+          ).then((pos) => ({ flow, pos })),
+        ),
+      );
+      if (!alive) return;
+      const labelByFlow = new Map<string, Node>();
+      const stepBase = new Map<string, XY>();
+      let yOffset = 0;
+      for (const { flow, pos } of perFlow) {
+        const ys = [...pos.values()].map((p) => p.y);
+        const minY = ys.length ? Math.min(...ys) : 0;
+        const maxY = ys.length ? Math.max(...ys) : 0;
+        labelByFlow.set(flow.id, {
+          id: `label:${flow.id}`,
+          type: "flowLabel",
+          position: { x: -200, y: yOffset },
+          data: { label: flow.workflowId, tags: flow.tags },
+          draggable: false,
+          selectable: false,
         });
+        for (const s of flow.steps) {
+          const p = pos.get(s.id) ?? FALLBACK_POS;
+          stepBase.set(s.id, { x: p.x, y: p.y - minY + yOffset });
+        }
+        yOffset += maxY - minY + 260;
+      }
+      setLayout({ labelByFlow, stepBase });
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [flows]);
+
+  // Edges depend on the flow structure and the highlight state, not on positions, so
+  // they stay referentially stable across a drag (React Flow re-routes them itself).
+  const edges = useMemo(() => {
+    const edges: Edge[] = [];
+    for (const flow of flows) {
+      for (const s of flow.steps) {
         for (const dep of s.dependsOn) {
           const active = related.steps.has(dep) && related.steps.has(s.id);
           edges.push({
@@ -163,15 +198,78 @@ function Graph({ graph, index, selection, related, onSelect, stepPositions, onMo
           });
         }
       }
-      yOffset += maxY - minY + 260;
     }
-    return { nodes, edges };
-  }, [flows, index, related, errored, selection, onSelect, stepPositions]);
+    return edges;
+  }, [flows, related]);
 
-  // Drags are reported up to the shell, which stages them (same loop as the ER tab).
-  const onNodesChange = useCallback(
-    (changes: NodeChange[]) => {
-      for (const c of changes) if (c.type === "position" && c.position) onMoveStep(c.id, c.position);
+  // Build nodes preserving object identity for unchanged steps (see entities-tab):
+  // dragging one step only changes its position, so only it is rebuilt — the rest of
+  // the graph keeps its references and doesn't re-render.
+  const nodeCache = useRef(new Map<string, { node: Node; sig: readonly unknown[] }>());
+  const targetNodes = useMemo(() => {
+    const cache = nodeCache.current;
+    const live = new Set<string>();
+    const out: Node[] = [];
+    for (const flow of flows) {
+      const label = layout.labelByFlow.get(flow.id);
+      if (label) {
+        out.push(label); // already stable (rebuilt only when `flows` changes)
+        live.add(label.id);
+      }
+      for (const s of flow.steps) {
+        live.add(s.id);
+        const position = stepPositions[s.id] ?? layout.stepBase.get(s.id) ?? FALLBACK_POS;
+        const resolvedOp = !s.operationId || !!index.endpointForStep(s);
+        const dim = related.steps.size > 0 && !related.steps.has(s.id);
+        const isErr = errored.has(s.id);
+        const selected = selection?.kind === "step" && selection.id === s.id;
+        const sig: readonly unknown[] = [s, position, resolvedOp, dim, isErr, selected, onSelect];
+        const prev = cache.get(s.id);
+        if (prev && prev.sig.every((v, i) => v === sig[i])) {
+          out.push(prev.node);
+          continue;
+        }
+        const node: Node = {
+          id: s.id,
+          type: "step",
+          position,
+          data: {
+            step: s,
+            resolvedOp,
+            dim,
+            errored: isErr,
+            onPick: (id: string) => onSelect({ kind: "step", id }),
+          } satisfies StepNodeData,
+          selected,
+        };
+        cache.set(s.id, { node, sig });
+        out.push(node);
+      }
+    }
+    for (const id of cache.keys()) if (!live.has(id)) cache.delete(id);
+    return out;
+  }, [layout, flows, stepPositions, index, related, errored, selection, onSelect]);
+
+  // React Flow owns positions during a drag; we only commit to the layout store on drag
+  // stop (same approach as the ER tab). Re-deriving the nodes array from the store every
+  // drag frame handed React Flow a fresh object for the node it was moving, which lost
+  // its measured size and flashed.
+  const [nodes, setNodes, onNodesChange] = useNodesState(targetNodes);
+  const dragging = useRef(false);
+  useEffect(() => {
+    if (dragging.current) return; // never clobber the step being moved mid-drag
+    setNodes(targetNodes);
+  }, [targetNodes, setNodes]);
+
+  const handleDragStart = useCallback(() => {
+    dragging.current = true;
+    onNodeDragStart();
+  }, []);
+  const handleDragStop = useCallback(
+    (_e: unknown, _node: Node, dragged: Node[]) => {
+      dragging.current = false;
+      onNodeDragStop();
+      for (const n of dragged) onMoveStep(n.id, n.position);
     },
     [onMoveStep],
   );
@@ -181,15 +279,23 @@ function Graph({ graph, index, selection, related, onSelect, stepPositions, onMo
     setTimeout(() => fitView({ padding: 0.2, duration: 300 }), 40);
   }, [onResetSteps, fitView]);
 
+  // Re-fit once positions resolve (layout is async) and on every re-flow.
   useEffect(() => {
     const t = setTimeout(() => fitView({ padding: 0.2, duration: 300 }), 80);
     return () => clearTimeout(t);
-  }, [flows, fitView]);
+  }, [layout, fitView]);
 
   if (!flows.length) {
     return (
       <div className="grid h-full place-items-center text-sm text-muted-foreground">
         {graph.flows.length ? "No workflows match the active tag filter." : "No Arazzo workflows found in this project."}
+      </div>
+    );
+  }
+  if (!layout.labelByFlow.size) {
+    return (
+      <div className="grid h-full place-items-center text-muted-foreground">
+        <Icon name="refresh" size={20} className="animate-spin" />
       </div>
     );
   }
@@ -199,6 +305,8 @@ function Graph({ graph, index, selection, related, onSelect, stepPositions, onMo
       edges={edges}
       nodeTypes={nodeTypes}
       onNodesChange={onNodesChange}
+      onNodeDragStart={handleDragStart}
+      onNodeDragStop={handleDragStop}
       onPaneClick={() => onSelect(null)}
       fitView
       minZoom={0.2}

--- a/packages/model-editor/src/spec/flows-tab.tsx
+++ b/packages/model-editor/src/spec/flows-tab.tsx
@@ -273,6 +273,8 @@ function Graph({ graph, index, selection, related, onSelect, stepPositions, onMo
     },
     [onMoveStep],
   );
+  // If we unmount mid-drag (drag-stop never fires), clear the global grabbing cursor.
+  useEffect(() => () => void (dragging.current && onNodeDragStop()), []);
 
   const resetLayout = useCallback(() => {
     onResetSteps();

--- a/packages/model-editor/src/spec/graph-types.ts
+++ b/packages/model-editor/src/spec/graph-types.ts
@@ -154,10 +154,65 @@ export interface SpecSource {
   resolved: boolean;
 }
 
+// ── Layer 4: events (AsyncAPI) ────────────────────────────────────────────────
+// The async counterpart to the HTTP contract: channels carry messages whose
+// payloads are (often) the same models the REST endpoints use. We read structure
+// only — channels, their send/receive operations, and message payload refs — and
+// link payloads back to entities and (best-effort) channels back to endpoints.
+
+export interface SpecMessage {
+  /** Message key/name within the document. */
+  name: string;
+  title?: string;
+  /** Referenced model name when the payload points at a named schema. */
+  payloadRef?: string;
+  /** Raw payload type when it isn't a named ref (inline object, primitive…). */
+  payloadType?: string;
+  contentType?: string;
+  doc?: string;
+}
+
+/** One AsyncAPI operation — 3.x `send`/`receive`, or a normalised 2.x publish/subscribe. */
+export interface SpecChannelOp {
+  /** Operation id (3.x operations map key, or 2.x `operationId`). */
+  id: string;
+  /** Direction from the application's perspective (2.x subscribe⇒receive, publish⇒send). */
+  action: "send" | "receive";
+  doc?: string;
+  /** Names of the messages this operation carries. */
+  messages: string[];
+}
+
+export interface SpecChannel {
+  /** Stable id == channel key (3.x) or channel name (2.x). */
+  id: string;
+  /** Display name — the channel key. */
+  name: string;
+  /** The channel address/topic/path (3.x `address`; 2.x falls back to the key). */
+  address?: string;
+  doc?: string;
+  /** Protocols this channel binds to, resolved from its servers (e.g. `sse`, `ws`). */
+  protocols?: string[];
+  operations: SpecChannelOp[];
+  messages: SpecMessage[];
+  /** De-duplicated model names referenced by any message payload. */
+  refModels: string[];
+  /**
+   * Explicit endpoint link hint from an `x-operationId` extension (channel or
+   * operation level). Validated against the contract in build-graph.
+   */
+  operationIdHint?: string;
+  /** Resolved endpoint id this channel links to (via {@link operationIdHint} or route match). */
+  endpointId?: string;
+  /** Tags from `tags: [{name}]`/`x-tags`, for view filtering. */
+  tags?: string[];
+  file?: string;
+}
+
 // ── Diagnostics ───────────────────────────────────────────────────────────────
 
 export type DiagnosticSeverity = "error" | "warning";
-export type SpecLayer = "tsp" | "arazzo" | "openapi" | "link";
+export type SpecLayer = "tsp" | "arazzo" | "openapi" | "asyncapi" | "link";
 
 export interface Diagnostic {
   severity: DiagnosticSeverity;
@@ -170,7 +225,7 @@ export interface Diagnostic {
 
 // ── The graph + selection ─────────────────────────────────────────────────────
 
-export type SelectionKind = "entity" | "endpoint" | "flow" | "step";
+export type SelectionKind = "entity" | "endpoint" | "flow" | "step" | "channel";
 
 export interface SelectionRef {
   kind: SelectionKind;
@@ -182,7 +237,7 @@ export interface SelectionRef {
 export interface SourceFile {
   id?: string;
   name: string;
-  kind: "tsp" | "openapi" | "arazzo";
+  kind: "tsp" | "openapi" | "arazzo" | "asyncapi";
   text: string;
 }
 
@@ -213,10 +268,12 @@ export interface ProjectGraph {
   models: SpecModel[];
   endpoints: SpecEndpoint[];
   flows: SpecFlow[];
+  /** Event-driven channels (AsyncAPI), the async projection of the contract. */
+  channels: SpecChannel[];
   sources: SpecSource[];
   diagnostics: Diagnostic[];
   /** Names of the files that fed the graph, grouped by kind (for the header). */
-  files: { tsp: string[]; openapi: string[]; arazzo: string[] };
+  files: { tsp: string[]; openapi: string[]; arazzo: string[]; asyncapi: string[] };
   /** Every discovered file with its raw text — the canonical source of truth. */
   sourceFiles: SourceFile[];
   /** Committed entity layout (from `canopy.layout.json`), with its named views. */
@@ -231,9 +288,10 @@ export const emptyGraph = (): ProjectGraph => ({
   models: [],
   endpoints: [],
   flows: [],
+  channels: [],
   sources: [],
   diagnostics: [],
-  files: { tsp: [], openapi: [], arazzo: [] },
+  files: { tsp: [], openapi: [], arazzo: [], asyncapi: [] },
   sourceFiles: [],
   layout: { version: 1, views: [{ id: "default", name: "Default", entities: {}, steps: {}, tagFilter: [] }] },
   empty: true,

--- a/packages/model-editor/src/spec/index.ts
+++ b/packages/model-editor/src/spec/index.ts
@@ -2,6 +2,7 @@ export * from "./graph-types";
 export { compileTypeSpec } from "./typespec";
 export { parseArazzo } from "./arazzo";
 export { parseOpenApi } from "./openapi";
-export { discoverProject, isTsp, isArazzo, type DiscoveryProvider, type SpecFileRef, type DiscoveredFiles } from "./discover";
+export { parseAsyncApi } from "./asyncapi";
+export { discoverProject, isTsp, isArazzo, isAsyncApi, type DiscoveryProvider, type SpecFileRef, type DiscoveredFiles } from "./discover";
 export { buildProjectGraph } from "./build-graph";
 export { SpecIndex, type RelatedSet } from "./links";

--- a/packages/model-editor/src/spec/layout.ts
+++ b/packages/model-editor/src/spec/layout.ts
@@ -1,12 +1,21 @@
-// A tiny dependency-layered layout shared by the Entities ER graph and the Flows
-// DAG. Nodes are placed in columns by longest-path depth from a root; within a
-// column they stack vertically. Cycles are tolerated (a back-edge just doesn't
-// deepen the target). Good enough for read-only diagrams without a layout dep.
+// Auto-layout shared by the Entities ER graph and the Flows DAG, backed by ELK
+// (the Eclipse Layout Kernel). React Flow ships no layout of its own; ELK's `layered`
+// (Sugiyama) algorithm ranks nodes left→right by dependency, minimizes edge crossings,
+// and packs each rank using the node's real width/height so tall entity cards never
+// overlap. It beats a plain layered stacker on ER graphs specifically: BRANDES_KOEPF
+// node placement keeps related cards aligned and orthogonal routing leaves clean gutters
+// for the FK edges. ELK is async (it returns a Promise), so callers compute layout in an
+// effect and store the result — see entities-tab / flows-tab.
+
+import ELK, { type ElkNode } from "elkjs/lib/elk.bundled.js";
 
 export interface LayoutItem {
   id: string;
-  /** Ids this node depends on / points at (drives the column it lands in). */
+  /** Ids this node depends on / points at; the edge that ranks it to the right. */
   deps: string[];
+  /** Rendered size. Slightly over-estimate height: extra gap is harmless, overlap isn't. */
+  width?: number;
+  height?: number;
 }
 
 export interface XY {
@@ -14,37 +23,68 @@ export interface XY {
   y: number;
 }
 
-export function layeredPositions(items: LayoutItem[], opts: { dx?: number; dy?: number } = {}): Map<string, XY> {
-  const dx = opts.dx ?? 300;
-  const dy = opts.dy ?? 140;
-  const ids = new Set(items.map((i) => i.id));
-  const depsById = new Map(items.map((i) => [i.id, i.deps.filter((d) => ids.has(d) && d !== i.id)]));
+export interface LayoutOpts {
+  /** Default node box when an item omits its size. */
+  width?: number;
+  height?: number;
+  /** Gap between nodes in the same rank (cross-axis) and between ranks (main-axis). */
+  nodesep?: number;
+  ranksep?: number;
+}
 
-  const depth = new Map<string, number>();
-  const computing = new Set<string>();
-  const depthOf = (id: string): number => {
-    if (depth.has(id)) return depth.get(id)!;
-    if (computing.has(id)) return 0; // cycle guard
-    computing.add(id);
-    const deps = depsById.get(id) ?? [];
-    const d = deps.length ? Math.max(...deps.map(depthOf)) + 1 : 0;
-    computing.delete(id);
-    depth.set(id, d);
-    return d;
-  };
-  for (const i of items) depthOf(i.id);
+// One engine for the whole module. `elk.bundled.js` runs in-thread (no worker setup),
+// and a single instance is reused across the many layout calls a session makes.
+const elk = new ELK();
 
-  const byColumn = new Map<number, string[]>();
-  for (const i of items) {
-    const d = depth.get(i.id) ?? 0;
-    if (!byColumn.has(d)) byColumn.set(d, []);
-    byColumn.get(d)!.push(i.id);
-  }
-
+/**
+ * Lay items out left→right by dependency and return each node's **top-left** position
+ * (ELK and React Flow agree on top-left origin, so no centre adjustment is needed).
+ * An empty input resolves to an empty map. Never throws: on an ELK failure it falls
+ * back to a simple stacked column so the canvas still renders.
+ */
+export async function layeredPositions(items: LayoutItem[], opts: LayoutOpts = {}): Promise<Map<string, XY>> {
   const pos = new Map<string, XY>();
-  for (const [col, members] of byColumn) {
-    const offset = ((members.length - 1) * dy) / 2;
-    members.forEach((id, row) => pos.set(id, { x: col * dx, y: row * dy - offset }));
+  if (!items.length) return pos;
+
+  const dw = opts.width ?? 230;
+  const dh = opts.height ?? 120;
+  const ids = new Set(items.map((i) => i.id));
+
+  const graph: ElkNode = {
+    id: "root",
+    layoutOptions: {
+      "elk.algorithm": "layered",
+      "elk.direction": "RIGHT",
+      // ranksep ↔ between layers (main axis); nodesep ↔ within a layer (cross axis).
+      "elk.layered.spacing.nodeNodeBetweenLayers": String(opts.ranksep ?? 110),
+      "elk.spacing.nodeNode": String(opts.nodesep ?? 48),
+      // Straightens chains of related cards and keeps the FK gutters clean.
+      "elk.layered.nodePlacement.strategy": "BRANDES_KOEPF",
+      "elk.layered.crossingMinimization.strategy": "LAYER_SWEEP",
+      "elk.layered.cycleBreaking.strategy": "GREEDY",
+      "elk.edgeRouting": "ORTHOGONAL",
+    },
+    children: items.map((i) => ({ id: i.id, width: i.width ?? dw, height: i.height ?? dh })),
+    edges: items.flatMap((i) =>
+      // dep ranks left of the node; skip self-loops and dangling refs with no node.
+      i.deps
+        .filter((dep) => dep !== i.id && ids.has(dep))
+        .map((dep) => ({ id: `${dep}->${i.id}`, sources: [dep], targets: [i.id] })),
+    ),
+  };
+
+  try {
+    const res = await elk.layout(graph);
+    for (const child of res.children ?? []) {
+      if (typeof child.x === "number" && typeof child.y === "number") pos.set(child.id, { x: child.x, y: child.y });
+    }
+  } catch {
+    // Degrade gracefully — a single column beats an empty canvas.
+    let y = 0;
+    for (const i of items) {
+      pos.set(i.id, { x: 0, y });
+      y += (i.height ?? dh) + (opts.nodesep ?? 48);
+    }
   }
   return pos;
 }

--- a/packages/model-editor/src/spec/layout.ts
+++ b/packages/model-editor/src/spec/layout.ts
@@ -67,7 +67,9 @@ export async function layeredPositions(items: LayoutItem[], opts: LayoutOpts = {
     children: items.map((i) => ({ id: i.id, width: i.width ?? dw, height: i.height ?? dh })),
     edges: items.flatMap((i) =>
       // dep ranks left of the node; skip self-loops and dangling refs with no node.
-      i.deps
+      // Dedupe deps so two fields pointing at the same target don't yield duplicate
+      // edge ids (ELK rejects collisions).
+      [...new Set(i.deps)]
         .filter((dep) => dep !== i.id && ids.has(dep))
         .map((dep) => ({ id: `${dep}->${i.id}`, sources: [dep], targets: [i.id] })),
     ),

--- a/packages/model-editor/src/spec/links.ts
+++ b/packages/model-editor/src/spec/links.ts
@@ -1,9 +1,9 @@
 // The cross-reference index — the heart of the feature. It turns the flat graph into
 // typed adjacency (endpoint↔entity, step→endpoint, flow→step) and answers the two
 // questions the UI asks constantly: "what does this select?" (selection-follows) and
-// "what uses this?" (find-usages), in both directions across all three layers.
+// "what uses this?" (find-usages), in both directions across all the layers.
 
-import type { ProjectGraph, SelectionRef, SpecEndpoint, SpecFlow, SpecModel, SpecStep } from "./graph-types";
+import type { ProjectGraph, SelectionRef, SpecChannel, SpecEndpoint, SpecFlow, SpecModel, SpecStep } from "./graph-types";
 
 /** Ids of related items per layer, used to highlight across tabs. */
 export interface RelatedSet {
@@ -11,6 +11,7 @@ export interface RelatedSet {
   endpoints: Set<string>;
   steps: Set<string>;
   flows: Set<string>;
+  channels: Set<string>;
 }
 
 const emptyRelated = (): RelatedSet => ({
@@ -18,6 +19,7 @@ const emptyRelated = (): RelatedSet => ({
   endpoints: new Set(),
   steps: new Set(),
   flows: new Set(),
+  channels: new Set(),
 });
 
 export class SpecIndex {
@@ -25,6 +27,7 @@ export class SpecIndex {
   readonly endpointById = new Map<string, SpecEndpoint>();
   readonly flowById = new Map<string, SpecFlow>();
   readonly stepById = new Map<string, SpecStep>();
+  readonly channelById = new Map<string, SpecChannel>();
 
   /** operationId → endpoint (== endpoint.id, kept explicit for clarity). */
   private readonly endpointByOp = new Map<string, SpecEndpoint>();
@@ -34,6 +37,10 @@ export class SpecIndex {
   private readonly stepsForEndpoint = new Map<string, Set<string>>();
   /** step id → its flow id. */
   private readonly flowForStep = new Map<string, string>();
+  /** model id → channels whose messages carry it. */
+  private readonly channelsForModel = new Map<string, Set<string>>();
+  /** endpoint id → channels linked to it. */
+  private readonly channelsForEndpoint = new Map<string, Set<string>>();
 
   readonly graph: ProjectGraph;
 
@@ -58,6 +65,17 @@ export class SpecIndex {
           if (!this.stepsForEndpoint.has(ep.id)) this.stepsForEndpoint.set(ep.id, new Set());
           this.stepsForEndpoint.get(ep.id)!.add(s.id);
         }
+      }
+    }
+    for (const c of graph.channels) {
+      this.channelById.set(c.id, c);
+      for (const ref of c.refModels) {
+        if (!this.channelsForModel.has(ref)) this.channelsForModel.set(ref, new Set());
+        this.channelsForModel.get(ref)!.add(c.id);
+      }
+      if (c.endpointId) {
+        if (!this.channelsForEndpoint.has(c.endpointId)) this.channelsForEndpoint.set(c.endpointId, new Set());
+        this.channelsForEndpoint.get(c.endpointId)!.add(c.id);
       }
     }
   }
@@ -89,6 +107,28 @@ export class SpecIndex {
     return e.refModels.map((id) => this.modelById.get(id)!).filter(Boolean);
   }
 
+  /** Channels whose messages carry a given model. */
+  channelsUsingModel(modelId: string): SpecChannel[] {
+    return [...(this.channelsForModel.get(modelId) ?? [])].map((id) => this.channelById.get(id)!).filter(Boolean);
+  }
+
+  /** Channels linked to a given endpoint (via x-operationId or route match). */
+  channelsForEndpointId(endpointId: string): SpecChannel[] {
+    return [...(this.channelsForEndpoint.get(endpointId) ?? [])].map((id) => this.channelById.get(id)!).filter(Boolean);
+  }
+
+  /** Models a channel's messages carry, de-duplicated in ref order. */
+  modelsForChannel(channelId: string): SpecModel[] {
+    const c = this.channelById.get(channelId);
+    if (!c) return [];
+    return c.refModels.map((id) => this.modelById.get(id)!).filter(Boolean);
+  }
+
+  /** The endpoint a channel links to, when one resolved. */
+  endpointForChannel(channel: SpecChannel): SpecEndpoint | undefined {
+    return channel.endpointId ? this.endpointById.get(channel.endpointId) : undefined;
+  }
+
   /** Flows that transitively reach a model (via any endpoint that references it). */
   flowsReachingModel(modelId: string): SpecFlow[] {
     const flows = new Set<string>();
@@ -110,6 +150,7 @@ export class SpecIndex {
         r.steps.add(s.id);
         r.flows.add(this.flowForStep.get(s.id)!);
       }
+      for (const c of this.channelsForEndpointId(id)) r.channels.add(c.id);
     };
 
     switch (selection.kind) {
@@ -120,11 +161,20 @@ export class SpecIndex {
         for (const f of m.fields) if (f.ref) r.entities.add(f.ref); // models it references
         for (const e of this.endpointsUsingModel(m.id)) addEndpoint(e.id);
         for (const f of this.flowsReachingModel(m.id)) r.flows.add(f.id);
+        for (const c of this.channelsUsingModel(m.id)) r.channels.add(c.id);
         break;
       }
       case "endpoint":
         addEndpoint(selection.id);
         break;
+      case "channel": {
+        const c = this.channelById.get(selection.id);
+        if (!c) return r;
+        r.channels.add(c.id);
+        for (const id of c.refModels) r.entities.add(id);
+        if (c.endpointId) addEndpoint(c.endpointId);
+        break;
+      }
       case "flow": {
         const f = this.flowById.get(selection.id);
         if (!f) return r;

--- a/packages/model-editor/src/spec/source-locate.ts
+++ b/packages/model-editor/src/spec/source-locate.ts
@@ -4,7 +4,7 @@
 // the untouched text is both simpler and accurate enough to anchor a "View source"
 // jump.
 
-import type { ProjectGraph, SelectionRef, SpecEndpoint, SpecFlow, SpecModel, SpecStep } from "./graph-types";
+import type { ProjectGraph, SelectionRef, SpecChannel, SpecEndpoint, SpecFlow, SpecModel, SpecStep } from "./graph-types";
 
 const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
@@ -35,6 +35,9 @@ const locateEndpoint = (text: string, e: SpecEndpoint) =>
 
 const locateFlow = (text: string, f: SpecFlow) => firstLine(text, new RegExp(`\\bworkflowId\\s*:\\s*["']?${esc(f.workflowId)}\\b`));
 const locateStep = (text: string, s: SpecStep) => firstLine(text, new RegExp(`\\bstepId\\s*:\\s*["']?${esc(s.stepId)}\\b`));
+// The channel key is a YAML map key under `channels:` — anchor on `<name>:`.
+const locateChannel = (text: string, c: SpecChannel) =>
+  firstLine(text, new RegExp(`^\\s*["']?${esc(c.name)}["']?\\s*:`, "m"), new RegExp(`\\baddress\\s*:\\s*["']?${esc(c.address ?? c.name)}\\b`));
 
 export interface SourceLocation {
   file: string;
@@ -62,6 +65,12 @@ export function locate(graph: ProjectGraph, ref: SelectionRef): SourceLocation |
     const text = textOf(f?.file);
     if (!f?.file || !text) return undefined;
     return { file: f.file, line: locateFlow(text, f) };
+  }
+  if (ref.kind === "channel") {
+    const c = graph.channels.find((x) => x.id === ref.id);
+    const text = textOf(c?.file);
+    if (!c?.file || !text) return undefined;
+    return { file: c.file, line: locateChannel(text, c) };
   }
   // step — its source line lives in the flow's Arazzo file
   const step = graph.flows.flatMap((f) => f.steps).find((s) => s.id === ref.id);

--- a/packages/model-editor/src/spec/source-tab.tsx
+++ b/packages/model-editor/src/spec/source-tab.tsx
@@ -11,8 +11,8 @@ export interface RevealTarget {
   nonce: number;
 }
 
-const KIND_ICON: Record<SourceFile["kind"], string> = { tsp: "file-code", openapi: "globe", arazzo: "board" };
-const KIND_LABEL: Record<SourceFile["kind"], string> = { tsp: "TypeSpec", openapi: "OpenAPI", arazzo: "Arazzo" };
+const KIND_ICON: Record<SourceFile["kind"], string> = { tsp: "file-code", openapi: "globe", asyncapi: "radio", arazzo: "board" };
+const KIND_LABEL: Record<SourceFile["kind"], string> = { tsp: "TypeSpec", openapi: "OpenAPI", asyncapi: "AsyncAPI", arazzo: "Arazzo" };
 
 const basename = (p: string) => p.replace(/[#?].*$/, "").split("/").pop()!.trim();
 
@@ -22,7 +22,7 @@ type Seg = { text: string } | { text: string; onClick: () => void; title: string
  * Reads the raw text of every discovered file and makes the references between them
  * navigable: `import`/`url`/`x-typespec-source` jump to the referenced file here;
  * an `operationId` jumps to the Endpoints tab. This is the "complete view" — the
- * three projection tabs plus the canonical source they're built from.
+ * projection tabs plus the canonical source they're built from.
  */
 export function SourceTab({ graph, onNavigate, reveal }: SpecViewProps & { reveal?: RevealTarget | null }) {
   const files = graph.sourceFiles;
@@ -101,7 +101,7 @@ export function SourceTab({ graph, onNavigate, reveal }: SpecViewProps & { revea
     <div className="flex h-full min-h-0">
       {/* File list */}
       <div className="w-56 shrink-0 overflow-y-auto border-r bg-muted/20 py-2">
-        {(["tsp", "openapi", "arazzo"] as const).map((kind) => {
+        {(["tsp", "openapi", "asyncapi", "arazzo"] as const).map((kind) => {
           const group = files.filter((f) => f.kind === kind);
           if (!group.length) return null;
           return (

--- a/packages/model-editor/src/spec/spec-editor-view.tsx
+++ b/packages/model-editor/src/spec/spec-editor-view.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Button } from "@canopy/ui";
 import {
   DropdownMenu,
@@ -15,6 +15,7 @@ import type { ProjectGraph, SelectionRef } from "./graph-types";
 import { SpecIndex } from "./links";
 import { EntitiesTab } from "./entities-tab";
 import { EndpointsTab } from "./endpoints-tab";
+import { ChannelsTab } from "./channels-tab";
 import { FlowsTab } from "./flows-tab";
 import { SourceTab } from "./source-tab";
 import { SpecInspector } from "./spec-inspector";
@@ -26,12 +27,14 @@ const FileChips = ({ graph }: { graph: ProjectGraph }) => (
   <div className="flex items-center gap-2 font-mono text-[11px] text-muted-foreground">
     {graph.files.tsp.length > 0 && <span className="flex items-center gap-1" title={graph.files.tsp.join(", ")}><Icon name="file-code" size={12} /> {graph.files.tsp.length} tsp</span>}
     {graph.files.openapi.length > 0 && <span className="flex items-center gap-1" title={graph.files.openapi.join(", ")}><Icon name="globe" size={12} /> {graph.files.openapi.length} openapi</span>}
+    {graph.files.asyncapi.length > 0 && <span className="flex items-center gap-1" title={graph.files.asyncapi.join(", ")}><Icon name="radio" size={12} /> {graph.files.asyncapi.length} asyncapi</span>}
     {graph.files.arazzo.length > 0 && <span className="flex items-center gap-1" title={graph.files.arazzo.join(", ")}><Icon name="board" size={12} /> {graph.files.arazzo.length} arazzo</span>}
   </div>
 );
 
 /**
- * The three-tab spec workspace. Selection lives here so it follows across tabs:
+ * The spec workspace (Entities · Endpoints · Channels · Flows · Source). Selection
+ * lives here so it follows across tabs:
  * `onSelect` highlights the related items everywhere (via {@link SpecIndex.related})
  * while staying put; `onNavigate` is the cross-layer jump that also switches tab.
  */
@@ -52,7 +55,9 @@ export function SpecEditorView({
   onReload?: () => void;
   reloading?: boolean;
 }) {
-  const [tab, setTab] = useState<SpecTab>(graph.endpoints.length || graph.models.length ? "entities" : "flows");
+  const [tab, setTab] = useState<SpecTab>(
+    graph.endpoints.length || graph.models.length ? "entities" : graph.flows.length ? "flows" : graph.channels.length ? "channels" : "flows",
+  );
   const [selection, setSelection] = useState<SelectionRef | null>(null);
   const [panelOpen, setPanelOpen] = useState(true);
   const [diagOpen, setDiagOpen] = useState(false);
@@ -70,24 +75,27 @@ export function SpecEditorView({
     for (const m of graph.models) m.tags?.forEach((t) => s.add(t));
     for (const f of graph.flows) f.tags?.forEach((t) => s.add(t));
     for (const e of graph.endpoints) e.tags?.forEach((t) => s.add(t));
+    for (const c of graph.channels) c.tags?.forEach((t) => s.add(t));
     return [...s].sort();
-  }, [graph.models, graph.flows, graph.endpoints]);
+  }, [graph.models, graph.flows, graph.endpoints, graph.channels]);
 
   const index = useMemo(() => new SpecIndex(graph), [graph]);
   const related = useMemo(() => index.related(selection), [index, selection]);
   const layout = useLayout(projectKey, graph, onCommitLayout);
   const activeView = layout.views.find((v) => v.id === layout.activeViewId);
 
-  const onSelect = (ref: SelectionRef | null) => setSelection(ref);
-  const onNavigate = (ref: SelectionRef) => {
+  // Stable identities: these flow into node `data` (e.g. each entity's onPick), so a
+  // fresh arrow per render would invalidate every node object on every drag frame.
+  const onSelect = useCallback((ref: SelectionRef | null) => setSelection(ref), []);
+  const onNavigate = useCallback((ref: SelectionRef) => {
     setSelection(ref);
     setTab(tabForKind(ref.kind));
     setPanelOpen(true);
-  };
-  const onOpenSource = (file: string, line?: number) => {
+  }, []);
+  const onOpenSource = useCallback((file: string, line?: number) => {
     setReveal((r) => ({ file, line, nonce: (r?.nonce ?? 0) + 1 }));
     setTab("source");
-  };
+  }, []);
   const toggleTag = (t: string) =>
     layout.setTagFilter(layout.tagFilter.includes(t) ? layout.tagFilter.filter((x) => x !== t) : [...layout.tagFilter, t]);
 
@@ -105,6 +113,7 @@ export function SpecEditorView({
           <TabsList>
             <TabsTrigger value="entities" className="gap-1.5"><Icon name="database" size={14} /> Entities <span className="font-mono text-[10px] text-muted-foreground">{showDtos ? graph.models.length : entityCount}</span></TabsTrigger>
             <TabsTrigger value="endpoints" className="gap-1.5"><Icon name="globe" size={14} /> Endpoints <span className="font-mono text-[10px] text-muted-foreground">{graph.endpoints.length}</span></TabsTrigger>
+            <TabsTrigger value="channels" className="gap-1.5"><Icon name="radio" size={14} /> Channels <span className="font-mono text-[10px] text-muted-foreground">{graph.channels.length}</span></TabsTrigger>
             <TabsTrigger value="flows" className="gap-1.5"><Icon name="board" size={14} /> Flows <span className="font-mono text-[10px] text-muted-foreground">{graph.flows.length}</span></TabsTrigger>
             <TabsTrigger value="source" className="gap-1.5"><Icon name="file-code" size={14} /> Source <span className="font-mono text-[10px] text-muted-foreground">{graph.sourceFiles.length}</span></TabsTrigger>
           </TabsList>
@@ -202,12 +211,13 @@ export function SpecEditorView({
       <div className="flex min-h-0 flex-1">
         <div className="relative min-w-0 flex-1">
           {/* Conceptually Entities + Endpoints are two projections of one contract;
-              Flows is a separate artifact referencing it. Mount only the active tab so
-              each React Flow canvas measures correctly. */}
+              Channels (events) and Flows are separate artifacts referencing it. Mount
+              only the active tab so each React Flow canvas measures correctly. */}
           {tab === "entities" && (
             <EntitiesTab {...shared} positions={layout.positions} onMove={layout.move} onResetLayout={layout.resetActive} hasOverrides={layout.hasOverrides} showDtos={showDtos} tagFilter={layout.tagFilter} />
           )}
           {tab === "endpoints" && <EndpointsTab {...shared} tagFilter={layout.tagFilter} />}
+          {tab === "channels" && <ChannelsTab {...shared} tagFilter={layout.tagFilter} />}
           {tab === "flows" && (
             <FlowsTab {...shared} stepPositions={layout.stepPositions} onMoveStep={layout.moveStep} onResetSteps={layout.resetSteps} hasStepOverrides={layout.hasStepOverrides} tagFilter={layout.tagFilter} />
           )}

--- a/packages/model-editor/src/spec/spec-editor-view.tsx
+++ b/packages/model-editor/src/spec/spec-editor-view.tsx
@@ -33,7 +33,7 @@ const FileChips = ({ graph }: { graph: ProjectGraph }) => (
 );
 
 /**
- * The spec workspace (Entities · Endpoints · Channels · Flows · Source). Selection
+ * The spec workspace (Entities · Endpoints · Events · Flows · Source). Selection
  * lives here so it follows across tabs:
  * `onSelect` highlights the related items everywhere (via {@link SpecIndex.related})
  * while staying put; `onNavigate` is the cross-layer jump that also switches tab.
@@ -113,7 +113,7 @@ export function SpecEditorView({
           <TabsList>
             <TabsTrigger value="entities" className="gap-1.5"><Icon name="database" size={14} /> Entities <span className="font-mono text-[10px] text-muted-foreground">{showDtos ? graph.models.length : entityCount}</span></TabsTrigger>
             <TabsTrigger value="endpoints" className="gap-1.5"><Icon name="globe" size={14} /> Endpoints <span className="font-mono text-[10px] text-muted-foreground">{graph.endpoints.length}</span></TabsTrigger>
-            <TabsTrigger value="channels" className="gap-1.5"><Icon name="radio" size={14} /> Channels <span className="font-mono text-[10px] text-muted-foreground">{graph.channels.length}</span></TabsTrigger>
+            <TabsTrigger value="channels" className="gap-1.5"><Icon name="radio" size={14} /> Events <span className="font-mono text-[10px] text-muted-foreground">{graph.channels.length}</span></TabsTrigger>
             <TabsTrigger value="flows" className="gap-1.5"><Icon name="board" size={14} /> Flows <span className="font-mono text-[10px] text-muted-foreground">{graph.flows.length}</span></TabsTrigger>
             <TabsTrigger value="source" className="gap-1.5"><Icon name="file-code" size={14} /> Source <span className="font-mono text-[10px] text-muted-foreground">{graph.sourceFiles.length}</span></TabsTrigger>
           </TabsList>

--- a/packages/model-editor/src/spec/spec-file-viewer.tsx
+++ b/packages/model-editor/src/spec/spec-file-viewer.tsx
@@ -11,7 +11,7 @@ import type { CommitLayoutFn } from "./use-layout";
 /**
  * Bridges a stored `.tsp`/`.arazzo` file to the spec editor: it reads the opened
  * file, scans its folder for the related contract/workflow/openapi files, builds the
- * cross-layer project graph, and renders the three-tab workspace over it. Read-only
+ * cross-layer project graph, and renders the spec workspace over it. Read-only
  * for now — write-back to the text files is a later phase.
  */
 export function SpecFileViewer({ fileId, fileName, spaceId, filePath }: FileViewProps) {

--- a/packages/model-editor/src/spec/spec-inspector.tsx
+++ b/packages/model-editor/src/spec/spec-inspector.tsx
@@ -45,7 +45,7 @@ export function SpecInspector({ graph, index, selection, onNavigate, onSelect, o
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center text-muted-foreground">
         <Icon name="link" size={22} />
-        <p className="text-[12px]">Select an entity, endpoint, or flow step to see its details and what references it across the other layers.</p>
+        <p className="text-[12px]">Select an entity, endpoint, channel, or flow step to see its details and what references it across the other layers.</p>
       </div>
     );
   }
@@ -57,6 +57,7 @@ export function SpecInspector({ graph, index, selection, onNavigate, onSelect, o
     if (!m) return <Empty text="This entity is no longer in the model." />;
     const endpoints = index.endpointsUsingModel(m.id);
     const flows = index.flowsReachingModel(m.id);
+    const channels = index.channelsUsingModel(m.id);
     return (
       <div className="flex h-full flex-col overflow-y-auto">
         <Header icon={m.kind === "enum" ? "list" : "database"} kind={m.kind === "enum" ? "Enum" : "Entity"} title={m.name} doc={m.doc} {...headerSource} />
@@ -98,6 +99,54 @@ export function SpecInspector({ graph, index, selection, onNavigate, onSelect, o
             <LinkRow key={f.id} icon="board" label={f.workflowId} onClick={() => onNavigate({ kind: "flow", id: f.id })} />
           )) : <Empty text="No flow reaches this entity." />}
         </Section>
+        {!!channels.length && (
+          <Section title="Carried by channels" count={channels.length}>
+            {channels.map((c) => (
+              <LinkRow key={c.id} icon="radio" label={c.name} sub={c.protocols?.join(", ")} onClick={() => onNavigate({ kind: "channel", id: c.id })} />
+            ))}
+          </Section>
+        )}
+      </div>
+    );
+  }
+
+  if (selection.kind === "channel") {
+    const c = index.channelById.get(selection.id);
+    if (!c) return <Empty text="This channel is no longer in the document." />;
+    const endpoint = index.endpointForChannel(c);
+    return (
+      <div className="flex h-full flex-col overflow-y-auto">
+        <Header icon="radio" kind="Channel" title={c.name} doc={c.doc} mono={[c.address, c.protocols?.join(", ")].filter(Boolean).join("  ·  ") || undefined} {...headerSource} />
+        {!!c.operations.length && (
+          <Section title="Operations" count={c.operations.length}>
+            {c.operations.map((op) => (
+              <div key={op.id} className="flex items-center gap-2 px-2 py-1 text-[12px]">
+                <span className={cn("rounded px-1 py-0.5 font-mono text-[9px] uppercase", op.action === "send" ? "bg-emerald-500/10 text-emerald-600" : "bg-sky-500/10 text-sky-600")}>{op.action}</span>
+                <span className="truncate font-mono text-[11px]">{op.id}</span>
+              </div>
+            ))}
+          </Section>
+        )}
+        <Section title="Messages" count={c.messages.length}>
+          {c.messages.length ? c.messages.map((msg) => (
+            msg.payloadRef && index.modelById.get(msg.payloadRef) ? (
+              <LinkRow key={msg.name} icon="database" label={msg.name} sub={nameOf(msg.payloadRef)} onClick={() => onNavigate({ kind: "entity", id: msg.payloadRef! })} />
+            ) : (
+              <div key={msg.name} className="flex items-center gap-2 px-2 py-1 text-[12px]">
+                <Icon name="bell" size={13} className="shrink-0 text-muted-foreground" />
+                <span className="font-medium">{msg.name}</span>
+                {(msg.payloadRef || msg.payloadType) && <span className="ml-auto truncate font-mono text-[11px] text-muted-foreground">{msg.payloadRef ?? msg.payloadType}</span>}
+              </div>
+            )
+          )) : <Empty text="No messages on this channel." />}
+        </Section>
+        <Section title="Linked endpoint">
+          {endpoint ? (
+            <LinkRow icon="globe" label={endpoint.operationId} sub={endpoint.verb?.toUpperCase()} onClick={() => onNavigate({ kind: "endpoint", id: endpoint.id })} />
+          ) : c.operationIdHint ? (
+            <LinkRow icon="alert-triangle" tone="error" label={c.operationIdHint} sub="unresolved" onClick={() => onSelect(selection)} />
+          ) : <Empty text="No HTTP endpoint linked." />}
+        </Section>
       </div>
     );
   }
@@ -106,6 +155,7 @@ export function SpecInspector({ graph, index, selection, onNavigate, onSelect, o
     const e = index.endpointById.get(selection.id);
     if (!e) return <Empty text="This endpoint is no longer in the contract." />;
     const steps = index.stepsCallingEndpoint(e.id);
+    const channels = index.channelsForEndpointId(e.id);
     return (
       <div className="flex h-full flex-col overflow-y-auto">
         <Header icon="globe" kind="Endpoint" title={e.operationId} doc={e.doc} mono={`${e.verb?.toUpperCase() ?? ""} ${e.route ?? ""}`.trim()} {...headerSource} />
@@ -137,6 +187,13 @@ export function SpecInspector({ graph, index, selection, onNavigate, onSelect, o
             <LinkRow key={s.id} icon="board" label={s.stepId} sub={s.workflowId} onClick={() => onNavigate({ kind: "step", id: s.id })} />
           )) : <Empty text="No flow step calls this endpoint." />}
         </Section>
+        {!!channels.length && (
+          <Section title="Channels" count={channels.length}>
+            {channels.map((c) => (
+              <LinkRow key={c.id} icon="radio" label={c.name} sub={c.protocols?.join(", ")} onClick={() => onNavigate({ kind: "channel", id: c.id })} />
+            ))}
+          </Section>
+        )}
       </div>
     );
   }

--- a/packages/model-editor/src/spec/use-layout.ts
+++ b/packages/model-editor/src/spec/use-layout.ts
@@ -13,6 +13,13 @@ import { deleteDraft, getDraft, putDraft } from "./drafts-store";
 /** Writes the sidecar text to the repo, returning the (possibly new) file id. */
 export type CommitLayoutFn = (text: string, fileId: string | undefined) => Promise<string | undefined>;
 
+// Stable empty fallbacks. Returning a fresh `{}`/`[]` from the render below would
+// give `positions`/`tagFilter` a new identity every render, which cascades into the
+// tabs' `useMemo`s and their `fitView` effects — re-fitting the canvas (snapping the
+// zoom) on every render, including every frame of a node drag.
+const EMPTY_POSITIONS: Record<string, XY> = {};
+const EMPTY_TAGS: string[] = [];
+
 export interface LayoutController {
   views: LayoutView[];
   activeViewId: string;
@@ -38,8 +45,6 @@ export interface LayoutController {
   resetSteps: () => void;
   commit: () => void;
 }
-
-const clone = (s: LayoutSidecar): LayoutSidecar => JSON.parse(JSON.stringify(s));
 
 export function useLayout(projectKey: string, graph: ProjectGraph, onCommit?: CommitLayoutFn): LayoutController {
   const [committed, setCommitted] = useState<LayoutSidecar>(graph.layout);
@@ -90,17 +95,31 @@ export function useLayout(projectKey: string, graph: ProjectGraph, onCommit?: Co
   }, [working, dirty, projectKey]);
 
   const activeView = working.views.find((v) => v.id === activeViewId) ?? working.views[0];
-  const positions = activeView?.entities ?? {};
-  const stepPositions = activeView?.steps ?? {};
-  const tagFilter = activeView?.tagFilter ?? [];
+  const positions = activeView?.entities ?? EMPTY_POSITIONS;
+  const stepPositions = activeView?.steps ?? EMPTY_POSITIONS;
+  const tagFilter = activeView?.tagFilter ?? EMPTY_TAGS;
 
   const mutateActive = useCallback(
     (fn: (v: LayoutView) => void) => {
       setWorking((w) => {
-        const next = clone(w);
-        const v = next.views.find((x) => x.id === activeViewId) ?? next.views[0];
-        if (v) fn(v);
-        return next;
+        // Structural sharing, not a deep clone: only the touched view (and its
+        // entities/steps maps, which the mutators write into) get fresh references.
+        // A deep clone here would hand every render new `entities`/`tagFilter`
+        // references, churning the tabs' memos and re-fitting the canvas on every
+        // drag frame (flicker + zoom snapping back). Unchanged entries keep identity,
+        // so dragging one node only invalidates that node.
+        const i = Math.max(0, w.views.findIndex((x) => x.id === activeViewId));
+        const cur = w.views[i];
+        if (!cur) return w;
+        const v: LayoutView = {
+          ...cur,
+          entities: { ...cur.entities },
+          ...(cur.steps ? { steps: { ...cur.steps } } : null),
+        };
+        fn(v);
+        const views = w.views.slice();
+        views[i] = v;
+        return { ...w, views };
       });
     },
     [activeViewId],

--- a/packages/model-editor/src/spec/use-layout.ts
+++ b/packages/model-editor/src/spec/use-layout.ts
@@ -114,7 +114,9 @@ export function useLayout(projectKey: string, graph: ProjectGraph, onCommit?: Co
         const v: LayoutView = {
           ...cur,
           entities: { ...cur.entities },
-          ...(cur.steps ? { steps: { ...cur.steps } } : null),
+          // `steps` is required; spreading an absent map yields {} so the clone always
+          // carries the field (and the step mutators can write into it safely).
+          steps: { ...cur.steps },
         };
         fn(v);
         const views = w.views.slice();

--- a/packages/model-editor/src/spec/view-types.ts
+++ b/packages/model-editor/src/spec/view-types.ts
@@ -17,10 +17,10 @@ export interface SpecViewProps {
   onOpenSource: (file: string, line?: number) => void;
 }
 
-export type SpecTab = "entities" | "endpoints" | "flows" | "source";
+export type SpecTab = "entities" | "endpoints" | "channels" | "flows" | "source";
 
 export const tabForKind = (kind: SelectionRef["kind"]): SpecTab =>
-  kind === "entity" ? "entities" : kind === "endpoint" ? "endpoints" : "flows";
+  kind === "entity" ? "entities" : kind === "endpoint" ? "endpoints" : kind === "channel" ? "channels" : "flows";
 
 export const sameRef = (a: SelectionRef | null, b: SelectionRef | null): boolean =>
   !!a && !!b && a.kind === b.kind && a.id === b.id;

--- a/packages/ui/src/icon.tsx
+++ b/packages/ui/src/icon.tsx
@@ -65,6 +65,9 @@ import {
   Timer,
   Calculator,
   Workflow,
+  Radio,
+  Send,
+  Inbox,
   type LucideIcon,
 } from "lucide-react";
 import type { CSSProperties } from "react";
@@ -140,6 +143,9 @@ const MAP: Record<string, LucideIcon> = {
   timer: Timer,
   calculator: Calculator,
   model: Workflow,
+  radio: Radio,
+  send: Send,
+  inbox: Inbox,
 };
 
 export function Icon({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,46 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
 
+  apps/model-editor-demo:
+    dependencies:
+      '@canopy/model-editor':
+        specifier: workspace:*
+        version: link:../../packages/model-editor
+      '@canopy/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      '@canopy/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
+      '@types/react':
+        specifier: ^19.2.15
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
+      react:
+        specifier: ^19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.0
+      typescript:
+        specifier: ~6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.13
+        version: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
+
   apps/portal:
     dependencies:
       '@canopy/core':
@@ -275,6 +315,9 @@ importers:
       '@vscode/vsce':
         specifier: ^3.6.0
         version: 3.9.2
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
       esbuild:
         specifier: ^0.25.0
         version: 0.25.12
@@ -379,6 +422,9 @@ importers:
       '@xyflow/react':
         specifier: ^12.11.0
         version: 12.11.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      elkjs:
+        specifier: ^0.11.1
+        version: 0.11.1
       idb:
         specifier: ^8.0.3
         version: 8.0.3
@@ -4342,6 +4388,9 @@ packages:
   electron-to-chromium@1.5.360:
     resolution: {integrity: sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==}
 
+  elkjs@0.11.1:
+    resolution: {integrity: sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -5160,6 +5209,7 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:
@@ -10793,6 +10843,8 @@ snapshots:
 
   electron-to-chromium@1.5.360: {}
 
+  elkjs@0.11.1: {}
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -10852,7 +10904,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -11277,7 +11329,7 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.3
+      hasown: 2.0.4
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
@@ -11498,7 +11550,7 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       side-channel: 1.1.0
 
   internmap@1.0.1: {}
@@ -11543,7 +11595,7 @@ snapshots:
 
   is-core-module@2.16.2:
     dependencies:
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   is-data-view@1.0.2:
     dependencies:
@@ -11610,7 +11662,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   is-regexp@1.0.0: {}
 


### PR DESCRIPTION
- README: install instructions pointing at the latest GitHub release.
- Release workflow: optional `vsce publish` (VSCE_PAT) and `ovsx publish` (OVSX_PAT) steps that run on a tag only when the secret is configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AsyncAPI support across the model editor (including parsing, routing, and a dedicated Channels tab).
  * Added a local, backend-free “Model Editor — Local Demo” with folder browsing and sample loading in the browser.
* **Documentation**
  * Expanded the VS Code extension README with an Install section and updated getting-started guidance.
  * Added a README for the local demo app, including usage instructions.
* **Bug Fixes**
  * Improved GitHub connector messaging for unauthenticated rate-limit failures.
* **Chores**
  * Enabled conditional automated publishing of the VS Code extension to VS Code Marketplace and Open VSX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->