### PR TITLE
Add Cloudflare AI Search adapter for hybrid document search

### DIFF
--- a/apps/api/src/ai/cloudflare.ts
+++ b/apps/api/src/ai/cloudflare.ts
@@ -15,16 +15,84 @@ export interface CloudflareModelSpec {
   id: string;
   label: string;
   vision?: boolean;
+  /** One-line "what it's good for", surfaced in model pickers. */
+  description?: string;
 }
 
 /**
- * The default Workers AI model(s) exposed when the binding is present. Gemma 4 26B
- * (MoE, 26B/4B-active, 256K context, vision) reads documents and images directly,
- * with no per-user key — the deployment pays. Add more by editing this list.
+ * The default Workers AI chat models exposed when the binding is present — no
+ * per-user key, the deployment pays. A curated menu replacing a Gemini Flash setup,
+ * grouped by task with a "powerhouse" and an "efficiency" pick each (see the
+ * `description` fields). The first entry is the zero-config default (`models[0]`); the
+ * host also routes by capability — images to the first vision model, code generation
+ * to a code model (see processors.ts / plugin-studio). Add or reorder freely.
+ *
+ * Embedding models are *not* chat models (they take no messages), so the embedding
+ * default lives separately in `CLOUDFLARE_EMBEDDING_MODEL` below.
  */
 export const CLOUDFLARE_MODELS: CloudflareModelSpec[] = [
-  { id: "@cf/google/gemma-4-26b-a4b-it", label: "Gemma 4 26B", vision: true },
+  // ── General / daily driver (vision) ──
+  {
+    id: "@cf/google/gemma-4-26b-a4b-it",
+    label: "Gemma 4 26B",
+    vision: true,
+    description:
+      "Daily driver for text, categorization, image vision, and JSON — its native reasoning track keeps long extractions syntactically clean.",
+  },
+  // ── Image analysis (vision) ──
+  {
+    id: "@cf/meta/llama-4-scout-17b-16e-instruct",
+    label: "Llama 4 Scout 17B",
+    vision: true,
+    description:
+      "Natively multimodal 16-expert MoE — industry-leading image understanding for pinpointing people and objects.",
+  },
+  {
+    id: "@cf/mistralai/mistral-small-3.1-24b-instruct",
+    label: "Mistral Small 3.1 24B",
+    vision: true,
+    description: "Efficient 24B with state-of-the-art vision — low-latency image tasks.",
+  },
+  // ── Code generation & heavy extraction ──
+  {
+    id: "@cf/moonshotai/kimi-k2.7-code",
+    label: "Kimi K2.7 Code",
+    vision: true,
+    description:
+      "Frontier 1T-param model, 262K context, structured outputs — powerhouse for massive document extraction and complex plugin code.",
+  },
+  {
+    id: "@cf/zai-org/glm-5.2",
+    label: "GLM-5.2",
+    description: "Z.ai's flagship agentic coding model — snappy specialized code synthesis, 262K context.",
+  },
+  {
+    id: "@cf/qwen/qwen2.5-coder-32b-instruct",
+    label: "Qwen2.5 Coder 32B",
+    description: "Developer-focused 32B code model — fast, specialized syntax generation.",
+  },
+  // ── Categorization / strict JSON ──
+  {
+    id: "@cf/openai/gpt-oss-120b",
+    label: "GPT-OSS 120B",
+    description:
+      "120B powerhouse for strict-JSON categorization — flawless schema adherence and logical consistency.",
+  },
+  {
+    id: "@cf/qwen/qwen3-30b-a3b-fp8",
+    label: "Qwen3 30B",
+    description:
+      "Efficient MoE with built-in reasoning and function calling — high-volume categorization at a fraction of the cost.",
+  },
 ];
+
+/**
+ * The default Workers AI embedding model — Qwen3-Embedding-0.6B (1024-dim, cosine,
+ * 4,096-token inputs, good for longer chunks). Used by the embedding/vector path
+ * (search ranking, Vectorize) rather than the chat gateway; kept here so the
+ * deployment's model choices live in one place.
+ */
+export const CLOUDFLARE_EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b";
 
 /** Pull text out of whatever shape the binding returned (chat `response` or OpenAI `choices`). */
 function extractText(out: unknown): string {
@@ -38,7 +106,13 @@ function extractText(out: unknown): string {
 
 /** An AI provider backed by the Workers AI binding. Only available on the Worker. */
 export function createCloudflareAi(binding: WorkersAiBinding, specs: CloudflareModelSpec[] = CLOUDFLARE_MODELS): AiProvider {
-  const models: AiModel[] = specs.map((m) => ({ id: m.id, label: m.label, provider: "cloudflare", vision: m.vision }));
+  const models: AiModel[] = specs.map((m) => ({
+    id: m.id,
+    label: m.label,
+    provider: "cloudflare",
+    vision: m.vision,
+    description: m.description,
+  }));
   return {
     models: () => models,
     async generate(req) {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -969,6 +969,19 @@ export function createApp(deps: AppDeps) {
     return c.json(await drive!.service.patchMetadata(caller, c.req.param("id")!, patch));
   }));
 
+  // Re-run the default processing pipeline for a single file: re-extract its text +
+  // re-feed the search index now (editor-gated), then re-run configured AI document
+  // processors over the current bytes off the response path — the same enrichment a
+  // fresh upload gets. Useful when a processor was added/reconfigured after upload, or
+  // a connector-backed file changed out-of-band. Returns 202: the AI pass is async.
+  app.post("/api/files/:id/reprocess", driveRoute(async (c, caller) => {
+    const id = c.req.param("id")!;
+    await drive!.service.reprocess(caller, id);
+    const file = await drive!.service.getFile(caller, id);
+    runBackground(labelFileInBackground(caller.sub, file));
+    return c.json({ ok: true }, 202);
+  }));
+
   // Stage a blob for a *specific file's* next version, keyed to the file's own
   // space and gated by editor on the file. Unlike /api/uploads/* (which keys by
   // ?space=), this can't land the blob in the wrong space, so the version POST

--- a/apps/api/src/processors.ts
+++ b/apps/api/src/processors.ts
@@ -107,10 +107,16 @@ export const documentAiProcessor: DocumentProcessor = {
   eligible: (_config, ctx) => !!ctx.ai && ctx.ai.models().length > 0,
   async process(file, config, ctx) {
     if (!ctx.ai) return { labels: [], error: "no AI provider configured on this server" };
-    // The user's choice, else the first model the host exposes (zero-config default).
-    const model = config.model?.trim() || ctx.ai.models()[0]?.id;
+    // Pick by task: the user's explicit choice wins; otherwise route images to a
+    // vision-capable model (Llama 3.2 Vision on Cloudflare) and everything else to
+    // the host's general default (`models[0]` — Qwen3 on Cloudflare). Capability-based,
+    // so a single-model provider (e.g. one Gemini model) still resolves correctly.
+    const models = ctx.ai.models();
+    const wantsVision = /^image\//i.test((file.mime || "").toLowerCase());
+    const model =
+      config.model?.trim() || (wantsVision ? models.find((m) => m.vision)?.id : undefined) || models[0]?.id;
     if (!model) return { labels: [], error: "no AI model available" };
-    const vision = ctx.ai.models().find((m) => m.id === model)?.vision ?? false;
+    const vision = models.find((m) => m.id === model)?.vision ?? false;
     const language = config.language?.trim() || DEFAULT_LANGUAGE;
     try {
       const out = await ctx.ai.generate({

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -5,6 +5,7 @@ import { AI_PROVIDER_FIELDS, providersFromUserConfig } from "./ai/user-config";
 import {
   FileService,
   createD1Db,
+  createAiSearchIndex,
   createR2BlobStore,
   createSqlBlobRepo,
   createSqlSearchIndex,
@@ -20,6 +21,7 @@ import {
   type D1Like,
   type FileRecord,
   type FileVersion,
+  type AiSearchInstance,
   type IndexJobs,
   type R2BucketLike,
 } from "@canopy/store";
@@ -43,6 +45,12 @@ interface WorkerEnv {
   DB: D1Like;
   /** Workers AI binding — when bound, the host exposes its models (Gemma) with no key. */
   AI?: WorkersAiBinding;
+  /** Cloudflare AI Search (AutoRAG) namespace binding. When bound *and* `AI_SEARCH_INSTANCE`
+   *  is set, search becomes hybrid (AI Search semantic recall fused with D1 FTS); otherwise
+   *  FTS5 alone. Duck-typed so `apps/api` stays free of `@cloudflare/workers-types`. */
+  AI_SEARCH?: AiSearchNamespace;
+  /** Name of the AI Search instance to query within the bound namespace. */
+  AI_SEARCH_INSTANCE?: string;
   /** GitHub repo ("owner/repo") backing the read-only documentation + demo mounts. */
   GITHUB_REPO?: string;
   GITHUB_BRANCH?: string;
@@ -67,6 +75,11 @@ interface WorkerEnv {
    *  impl). Optional — absent (e.g. Node, or before the Workflow is provisioned) → the
    *  in-process loop runs instead. Duck-typed, like the DO bindings above. */
   CONNECTOR_INDEX?: IndexWorkflowBinding;
+}
+
+/** The slice of the AI Search namespace binding we use: resolve one instance by name. */
+interface AiSearchNamespace {
+  get(name: string): AiSearchInstance;
 }
 
 /** The slice of the connector-index Workflow binding we use (duck-typed). */
@@ -136,7 +149,14 @@ export async function buildDeps(env: WorkerEnv, waitUntil?: (p: Promise<unknown>
   const db = createD1Db(env.DB);
   await (schemaReady ??= runMigrations(db));
   const blobs = createR2BlobStore(env.BUCKET);
-  const search = createSqlSearchIndex(db);
+  // FTS5 is always the feed + title/metadata backend. When an AI Search instance
+  // is bound, wrap it for hybrid (semantic content) recall; the FTS index stays
+  // the source for filename/label/tag matching.
+  const fts = createSqlSearchIndex(db);
+  const search =
+    env.AI_SEARCH && env.AI_SEARCH_INSTANCE
+      ? createAiSearchIndex({ db, instance: env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE), fts })
+      : fts;
   const authConfig = readAuthConfig(env as unknown as EnvVars);
   const { plugins, connectorFor, connectorForUser, readExternal } = connectorWiring(env, db, authConfig);
   const channel = env.SPACE_CHANNEL;

--- a/apps/portal/src/App.tsx
+++ b/apps/portal/src/App.tsx
@@ -46,6 +46,8 @@ import {
   setItemOffline,
   reconcilePins,
   moveFile,
+  renameFile,
+  reprocessFile,
   setSpaceMounted,
   syncConnector,
   clearSpaceContent,
@@ -876,6 +878,32 @@ function DesktopApp() {
       setShareTarget({ target, label: f.name });
     } else if (action === "Download" && f.kind !== "folder") {
       downloadFile(f.id, f.name);
+    } else if (action === "Rename") {
+      // Folders are virtual (a derived path, not a row), so there's nothing to rename.
+      if (f.kind === "folder") {
+        toast("Folders can't be renamed yet");
+        return;
+      }
+      const name = window.prompt("Rename file", f.name);
+      if (!name?.trim() || name.trim() === f.name) return;
+      const next = name.trim();
+      setFiles((fs) => fs.map((x) => (x.id === f.id ? { ...x, name: next } : x))); // optimistic
+      try {
+        await renameFile(f.id, next);
+        reload();
+        toast(`Renamed to “${next}”`);
+      } catch (err) {
+        reload(); // rollback to server truth
+        toast("Couldn't rename", { description: (err as Error).message });
+      }
+    } else if (action === "Reprocess") {
+      if (f.kind === "folder") return; // folders have no content to process
+      try {
+        await reprocessFile(f.id);
+        toast("Reprocessing…", { description: `Re-indexing “${f.name}” and re-running AI labels.` });
+      } catch (err) {
+        toast("Couldn't reprocess", { description: (err as Error).message });
+      }
     } else {
       toast(action, { description: f.name });
     }

--- a/apps/portal/src/components/file-table.tsx
+++ b/apps/portal/src/components/file-table.tsx
@@ -412,6 +412,12 @@ export function FileTable({
                     {f.offline ? "Remove download" : "Available offline"}
                   </ContextMenuItem>
                   <ContextMenuItem onSelect={() => onAction("Move", f)}>Move</ContextMenuItem>
+                  {f.kind !== "folder" && (
+                    <ContextMenuItem onSelect={() => onAction("Reprocess", f)}>
+                      <Icon name="sparkles" size={15} />
+                      Reprocess
+                    </ContextMenuItem>
+                  )}
                   {pluginItems.length > 0 && <ContextMenuSeparator />}
                   {pluginItems.map((item) => (
                     <ContextMenuItem key={item.pluginId + item.label} onSelect={() => onAction(item.label, f)}>

--- a/apps/portal/src/components/plugin-slot.tsx
+++ b/apps/portal/src/components/plugin-slot.tsx
@@ -132,13 +132,23 @@ const BOOTSTRAP = `<!doctype html>
 
 type Status = "loading" | "ready" | "error";
 
+/** Cheap, stable signature of a string — distinguishes one plugin source from another. */
+function sig(s: string): string {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (Math.imul(h, 31) + s.charCodeAt(i)) | 0;
+  return `${s.length}.${h >>> 0}`;
+}
+
 /**
  * Mount a plugin-contributed UI slot in the sandbox.
  *
- * Mount with a `key` tied to `${plugin}:${slot}` so switching plugins remounts
- * the frame cleanly. `capabilities` may change identity between renders without
- * re-initialising the frame — the latest map is read from a ref when a call
- * arrives — so the theme/source captured at init stay stable.
+ * The iframe is keyed by `${plugin}:${slot}:${sig(source)}` so switching plugins
+ * — or regenerating the same one with new source — remounts a fresh frame. This
+ * is essential: `srcDoc` is static, so the `canopy:slot-ready` handshake fires
+ * only on (re)load; without a remount a new `source` would never be initialised
+ * and the old plugin would keep running. `capabilities` may change identity
+ * between renders without re-initialising the frame — the latest map is read from
+ * a ref when a call arrives — so the theme/source captured at init stay stable.
  */
 export function PluginSlot({
   plugin,
@@ -228,6 +238,7 @@ export function PluginSlot({
 
   return (
     <iframe
+      key={`${plugin}:${slot}:${sig(source)}`}
       ref={iframeRef}
       title={`${plugin} ${slot}`}
       // No allow-same-origin: the frame gets a unique opaque origin.

--- a/apps/portal/src/components/plugin-studio-view.tsx
+++ b/apps/portal/src/components/plugin-studio-view.tsx
@@ -11,10 +11,14 @@ import { cn } from "@/lib/utils";
 import { aiGenerate, listAiModels, saveCustomPlugin, type AiModel, type CustomPlugin } from "@/lib/api";
 import {
   buildGenerationMessages,
+  buildRefinementMessages,
   parseGeneratedPlugin,
   type GeneratedPlugin,
   type PluginKind,
 } from "@/lib/plugin-author-prompt";
+
+/** Studio mode: build a fresh plugin, or iterate on the one already in the panel. */
+type StudioMode = "create" | "refine";
 
 /**
  * Plugin Studio — describe an idea, the **core LLM** writes a sandboxed viewer
@@ -38,13 +42,16 @@ export function PluginStudioView({
   const [models, setModels] = useState<AiModel[] | null>(null); // null = still loading
   const [model, setModel] = useState("");
   const [kind, setKind] = useState<PluginKind>("viewer");
+  const [mode, setMode] = useState<StudioMode>("create");
   const [idea, setIdea] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [generated, setGenerated] = useState<GeneratedPlugin | null>(null);
+  const [name, setName] = useState(""); // editable display name applied at install
   const [installed, setInstalled] = useState(false);
   const [sample, setSample] = useState<{ name: string; url: string } | null>(null);
   const fileInput = useRef<HTMLInputElement>(null);
+  const topRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     listAiModels().then((m) => {
@@ -65,13 +72,20 @@ export function PluginStudioView({
   }, [sample]);
 
   async function generate() {
+    // Refine the current plugin (feed its manifest+source back as context) when in
+    // refine mode with something to refine; otherwise build a fresh plugin.
+    const refining = mode === "refine" && !!generated;
     setBusy(true);
     setError(null);
     setInstalled(false);
-    setGenerated(null);
+    if (!refining) setGenerated(null); // keep the current preview while refining
     try {
+      // Carry the current (possibly renamed) name into the refine context so it
+      // survives the round-trip — the model is told to keep the manifest as-is bar
+      // the change.
+      const current = generated && { ...generated, manifest: { ...generated.manifest, name: name.trim() || generated.manifest.name } };
       const text = await aiGenerate({
-        messages: buildGenerationMessages(idea, kind),
+        messages: refining ? buildRefinementMessages(idea, current!) : buildGenerationMessages(idea, kind),
         model: model || undefined,
         // The contract asks for two fenced blocks (manifest + source), not one JSON
         // object — so we don't force strict JSON mode (which not every model supports,
@@ -81,7 +95,12 @@ export function PluginStudioView({
         // their own limit. The server caps at AI_MAX_TOKENS regardless.
         maxTokens: 16384,
       });
-      setGenerated(parseGeneratedPlugin(text));
+      const next = parseGeneratedPlugin(text);
+      setGenerated(next);
+      setName(next.manifest.name);
+      // Once a plugin exists, the natural next step is to iterate on it.
+      setMode("refine");
+      setIdea("");
     } catch (e) {
       setError((e as Error).message);
     } finally {
@@ -91,18 +110,41 @@ export function PluginStudioView({
 
   async function install() {
     if (!generated) return;
+    const finalName = name.trim() || generated.manifest.name;
     setBusy(true);
     setError(null);
     try {
-      await saveCustomPlugin(generated.manifest, generated.source);
+      // The user names the plugin at save time; everything else comes from the manifest.
+      await saveCustomPlugin({ ...generated.manifest, name: finalName }, generated.source);
       setInstalled(true);
       onInstalled?.();
-      toast("Plugin installed", { description: `“${generated.manifest.name}” is now active.` });
+      toast("Plugin installed", { description: `“${finalName}” is now active.` });
     } catch (e) {
       setError((e as Error).message);
     } finally {
       setBusy(false);
     }
+  }
+
+  /** Load an already-generated plugin back into the panel to refine it. */
+  function loadForRefine(p: CustomPlugin) {
+    setGenerated({ manifest: p.manifest, source: p.source });
+    setName(p.manifest.name);
+    setMode("refine");
+    setIdea("");
+    setInstalled(false);
+    setError(null);
+    topRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  /** Clear the panel and start a fresh plugin from scratch. */
+  function startNew() {
+    setMode("create");
+    setGenerated(null);
+    setName("");
+    setIdea("");
+    setInstalled(false);
+    setError(null);
   }
 
   function pickSample(f: File | undefined) {
@@ -138,7 +180,7 @@ export function PluginStudioView({
   const previewAsApp = !!detailView;
 
   return (
-    <div className="mx-auto flex max-w-2xl flex-col gap-6 py-1">
+    <div ref={topRef} className="mx-auto flex max-w-2xl flex-col gap-6 py-1">
       {/* Header */}
       <div className="flex items-start gap-3.5">
         <div
@@ -156,27 +198,50 @@ export function PluginStudioView({
         </div>
       </div>
 
-      {/* Kind + idea + model */}
+      {/* Mode + kind + idea + model */}
       <div className="flex flex-col gap-2">
-        <div className="inline-flex self-start rounded-md border p-0.5 text-[13px]">
-          {([
-            ["viewer", "File viewer"],
-            ["app", "App"],
-          ] as const).map(([k, label]) => (
-            <button
-              key={k}
-              onClick={() => setKind(k)}
-              className={cn(
-                "rounded-[5px] px-3 py-1 transition-colors",
-                kind === k ? "bg-accent font-medium text-foreground" : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
+        {/* Refine vs. create — only meaningful once a plugin is in the panel. */}
+        {generated && (
+          <div className="inline-flex self-start rounded-md border p-0.5 text-[13px]">
+            {([
+              ["refine", "Refine current"],
+              ["create", "Create new"],
+            ] as const).map(([mo, label]) => (
+              <button
+                key={mo}
+                onClick={() => (mo === "create" ? startNew() : setMode("refine"))}
+                className={cn(
+                  "rounded-[5px] px-3 py-1 transition-colors",
+                  mode === mo ? "bg-accent font-medium text-foreground" : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
+        {/* Viewer vs. app — only when creating; a refine keeps the existing kind. */}
+        {mode === "create" && (
+          <div className="inline-flex self-start rounded-md border p-0.5 text-[13px]">
+            {([
+              ["viewer", "File viewer"],
+              ["app", "App"],
+            ] as const).map(([k, label]) => (
+              <button
+                key={k}
+                onClick={() => setKind(k)}
+                className={cn(
+                  "rounded-[5px] px-3 py-1 transition-colors",
+                  kind === k ? "bg-accent font-medium text-foreground" : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
         <label htmlFor="studio-idea" className="text-[13px] font-medium">
-          What should it do?
+          {mode === "refine" ? "What should change?" : "What should it do?"}
         </label>
         <textarea
           id="studio-idea"
@@ -184,9 +249,11 @@ export function PluginStudioView({
           onChange={(e) => setIdea(e.target.value)}
           rows={3}
           placeholder={
-            kind === "app"
-              ? "e.g. A snake game, a pomodoro timer, or a unit converter"
-              : "e.g. Render .gpx GPS tracks on a small map, or show EXIF metadata for photos"
+            mode === "refine"
+              ? "e.g. Make the snake faster, add a score counter, fix the reset button"
+              : kind === "app"
+                ? "e.g. A snake game, a pomodoro timer, or a unit converter"
+                : "e.g. Render .gpx GPS tracks on a small map, or show EXIF metadata for photos"
           }
           className="w-full resize-y rounded-md border bg-transparent px-3 py-2 text-[14px] outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
         />
@@ -206,13 +273,21 @@ export function PluginStudioView({
             </Select>
           )}
           <Button onClick={generate} disabled={busy || !idea.trim() || models === null} className="gap-1.5">
-            {busy && !generated ? <Loader2 size={15} className="animate-spin" /> : <Sparkles size={15} />}
-            {busy && !generated ? "Generating…" : generated ? "Regenerate" : "Generate plugin"}
+            {busy ? <Loader2 size={15} className="animate-spin" /> : <Sparkles size={15} />}
+            {busy
+              ? mode === "refine"
+                ? "Refining…"
+                : "Generating…"
+              : mode === "refine"
+                ? "Refine plugin"
+                : "Generate plugin"}
           </Button>
           <span className="text-[12px] text-muted-foreground">
-            {kind === "app"
-              ? "An app launches from its own section in the sidebar."
-              : "A viewer opens when you preview a matching file."}
+            {mode === "refine"
+              ? "Describe a change — the AI rewrites the current plugin."
+              : kind === "app"
+                ? "An app launches from its own section in the sidebar."
+                : "A viewer opens when you preview a matching file."}
           </span>
         </div>
       </div>
@@ -236,7 +311,7 @@ export function PluginStudioView({
             </div>
             <div className="min-w-0 flex-1">
               <div className="font-medium">
-                {m.name} <span className="font-mono text-[12px] text-muted-foreground">{m.id}</span>
+                {name || m.name} <span className="font-mono text-[12px] text-muted-foreground">{m.id}</span>
               </div>
               {m.description && <p className="text-[12.5px] text-muted-foreground">{m.description}</p>}
               <div className="mt-1.5 flex flex-wrap gap-1.5">
@@ -306,9 +381,24 @@ export function PluginStudioView({
             </pre>
           </details>
 
-          {/* Install */}
+          {/* Name + install */}
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="studio-name" className="text-[13px] font-medium">
+              Name
+            </label>
+            <input
+              id="studio-name"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setInstalled(false); // renaming after install means there's a new version to save
+              }}
+              placeholder={m.name}
+              className="h-9 w-full rounded-md border bg-transparent px-3 text-[14px] outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          </div>
           <div className="flex items-center gap-2">
-            <Button onClick={install} disabled={busy || installed} className="gap-1.5">
+            <Button onClick={install} disabled={busy || installed || !name.trim()} className="gap-1.5">
               {installed ? <Check size={15} /> : busy ? <Loader2 size={15} className="animate-spin" /> : <Icon name="plugin" size={15} />}
               {installed ? "Installed" : "Install plugin"}
             </Button>
@@ -343,6 +433,14 @@ export function PluginStudioView({
                     <div className="truncate text-[13px] font-medium">{p.manifest.name}</div>
                     <div className="truncate font-mono text-[11px] text-muted-foreground">{ms.join(", ")}</div>
                   </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1.5 text-muted-foreground hover:text-foreground"
+                    onClick={() => loadForRefine(p)}
+                  >
+                    <Sparkles size={14} /> Refine
+                  </Button>
                   <Button
                     variant="ghost"
                     size="sm"

--- a/apps/portal/src/components/plugin-studio-view.tsx
+++ b/apps/portal/src/components/plugin-studio-view.tsx
@@ -49,7 +49,11 @@ export function PluginStudioView({
   useEffect(() => {
     listAiModels().then((m) => {
       setModels(m);
-      if (m[0]) setModel(m[0].id);
+      // Default to a code model when the host exposes one (Qwen2.5 Coder on
+      // Cloudflare) — it's the task here — else the host's general default.
+      const coder = m.find((x) => /\b(coder|code)\b/i.test(`${x.id} ${x.label}`));
+      const pick = coder ?? m[0];
+      if (pick) setModel(pick.id);
     });
   }, []);
 

--- a/apps/portal/src/components/settings-view.tsx
+++ b/apps/portal/src/components/settings-view.tsx
@@ -204,7 +204,7 @@ function AiModelsSection() {
               <span
                 key={m.id}
                 className="inline-flex items-center gap-1.5 rounded-full border bg-background px-2.5 py-1 text-[12px]"
-                title={m.id}
+                title={m.description ? `${m.id}\n\n${m.description}` : m.id}
               >
                 {m.label}
                 <span className="text-muted-foreground">· {m.provider}</span>

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -752,6 +752,14 @@ export async function deleteFile(id: string): Promise<void> {
   if (!res.ok) throw new Error(`delete failed: ${res.status}`);
 }
 
+/** Re-run the processing pipeline for a file: re-extract text, re-index for search,
+ *  and re-run AI document processors (labels/description). The AI pass runs server-side
+ *  off the response path, so this resolves once the re-index is queued. */
+export async function reprocessFile(id: string): Promise<void> {
+  const res = await apiFetch(`/api/files/${id}/reprocess`, { method: "POST" });
+  if (!res.ok) throw new Error(`reprocess failed: ${res.status}`);
+}
+
 /** Files in the caller's Trash, newest deletion first. */
 export async function listTrash(): Promise<FileItem[]> {
   const res = await apiFetch("/api/files?trash=1");
@@ -854,6 +862,16 @@ export async function moveFile(id: string, path: string): Promise<void> {
     body: JSON.stringify({ path }),
   });
   if (!res.ok) throw new Error(`move failed: ${res.status}`);
+}
+
+/** Rename a file — persisted as the file's `name` column (a metadata edit, no new version). */
+export async function renameFile(id: string, name: string): Promise<void> {
+  const res = await apiFetch(`/api/files/${id}/metadata`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) throw new Error(`rename failed: ${res.status}`);
 }
 
 /** Create an empty folder at a virtual path within a space. */

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -1636,6 +1636,8 @@ export interface AiModel {
   label: string;
   provider: string;
   vision?: boolean;
+  /** One-line "what it's good for", shown as a tooltip in the model list. */
+  description?: string;
 }
 
 /** Models available for plugins to use, or [] when the server has no AI provider. */

--- a/apps/portal/src/lib/plugin-author-prompt.ts
+++ b/apps/portal/src/lib/plugin-author-prompt.ts
@@ -154,6 +154,9 @@ export function buildRefinementMessages(instruction: string, current: GeneratedP
   const isApp = !!current.manifest.contributes?.detailView;
   const system = isApp ? SYSTEM_APP : SYSTEM_VIEWER;
   const manifestJson = JSON.stringify(current.manifest, null, 2);
+  // Plugin manifest/source are arbitrary content and may themselves contain ``` runs;
+  // pick a fence longer than any run inside the payload so it can't be broken out of.
+  const fence = fenceFor(manifestJson, current.source);
   return [
     { role: "system", content: system },
     {
@@ -162,11 +165,20 @@ export function buildRefinementMessages(instruction: string, current: GeneratedP
         `Here is an existing Canopy ${isApp ? "app" : "file-viewer"} plugin. Apply the requested change and ` +
         `return the COMPLETE updated plugin in the same two fenced blocks (a full manifest and a full index.js) ` +
         `— not a diff or only the changed parts. Keep the same manifest id.\n\n` +
-        `Current manifest:\n\`\`\`json\n${manifestJson}\n\`\`\`\n\n` +
-        `Current index.js:\n\`\`\`js\n${current.source}\n\`\`\`\n\n` +
+        `Current manifest:\n${fence}json\n${manifestJson}\n${fence}\n\n` +
+        `Current index.js:\n${fence}js\n${current.source}\n${fence}\n\n` +
         `Change to apply: ${instruction.trim()}\n\nReturn only the two fenced blocks described above.`,
     },
   ];
+}
+
+/** A backtick fence guaranteed not to collide with any backtick run inside the given payloads. */
+function fenceFor(...payloads: string[]): string {
+  let longest = 0;
+  for (const p of payloads) {
+    for (const m of p.matchAll(/`+/g)) longest = Math.max(longest, m[0].length);
+  }
+  return "`".repeat(Math.max(3, longest + 1));
 }
 
 /** A fenced ```lang … ``` block. `lang` is lowercased, "" when the model omitted it. */

--- a/apps/portal/src/lib/plugin-author-prompt.ts
+++ b/apps/portal/src/lib/plugin-author-prompt.ts
@@ -143,6 +143,32 @@ export function buildGenerationMessages(idea: string, kind: PluginKind = "viewer
   ];
 }
 
+/**
+ * System + user messages to *refine* an existing plugin: the model gets the
+ * current manifest and source plus a change instruction, and returns the COMPLETE
+ * updated plugin in the same two-block format. The plugin kind (and so the system
+ * prompt) is inferred from the manifest — an app contributes a detailView, a
+ * viewer contributes viewers — so the caller doesn't pass it.
+ */
+export function buildRefinementMessages(instruction: string, current: GeneratedPlugin): AiMessage[] {
+  const isApp = !!current.manifest.contributes?.detailView;
+  const system = isApp ? SYSTEM_APP : SYSTEM_VIEWER;
+  const manifestJson = JSON.stringify(current.manifest, null, 2);
+  return [
+    { role: "system", content: system },
+    {
+      role: "user",
+      content:
+        `Here is an existing Canopy ${isApp ? "app" : "file-viewer"} plugin. Apply the requested change and ` +
+        `return the COMPLETE updated plugin in the same two fenced blocks (a full manifest and a full index.js) ` +
+        `— not a diff or only the changed parts. Keep the same manifest id.\n\n` +
+        `Current manifest:\n\`\`\`json\n${manifestJson}\n\`\`\`\n\n` +
+        `Current index.js:\n\`\`\`js\n${current.source}\n\`\`\`\n\n` +
+        `Change to apply: ${instruction.trim()}\n\nReturn only the two fenced blocks described above.`,
+    },
+  ];
+}
+
 /** A fenced ```lang … ``` block. `lang` is lowercased, "" when the model omitted it. */
 interface Fence {
   lang: string;

--- a/apps/portal/src/mobile/mobile-app.tsx
+++ b/apps/portal/src/mobile/mobile-app.tsx
@@ -95,6 +95,10 @@ export function MobileApp() {
   const signOut = async () => {
     await logout();
     setAuth((a) => ({ ...a, user: null }));
+    setSpaces([]);
+    // Remount auth-scoped screens (recent files, space counts) so they refetch
+    // against the now signed-out session instead of showing stale data.
+    setRefreshKey((k) => k + 1);
   };
 
   async function createNote() {

--- a/apps/portal/src/mobile/mobile-app.tsx
+++ b/apps/portal/src/mobile/mobile-app.tsx
@@ -11,6 +11,7 @@ import {
   uploadFiles,
   createFile,
   loginUrl,
+  logout,
   type Me,
   type SpaceView,
 } from "@/lib/api";
@@ -91,6 +92,11 @@ export function MobileApp() {
     window.location.href = loginUrl(window.location.pathname + window.location.search);
   };
 
+  const signOut = async () => {
+    await logout();
+    setAuth((a) => ({ ...a, user: null }));
+  };
+
   async function createNote() {
     const creator = CREATORS.find((c) => c.extension === ".md");
     if (!creator) return;
@@ -127,11 +133,14 @@ export function MobileApp() {
         {view === "home" && (
           <HomeScreen
             userName={userName}
+            auth={auth}
             spaceCount={spaces.filter((s) => s.kind === "group").length}
             installed={installed}
             refreshKey={refreshKey}
             onOpenFile={openFile}
             onNav={(v) => setView(v as View)}
+            onSignIn={signIn}
+            onSignOut={signOut}
           />
         )}
         {view === "drive" && <DriveScreen refreshKey={refreshKey} onOpenFile={openFile} />}

--- a/apps/portal/src/mobile/screens.tsx
+++ b/apps/portal/src/mobile/screens.tsx
@@ -121,11 +121,11 @@ function AccountMenu({
               <Icon name="log-out" size={15} /> Sign out
             </DropdownMenuItem>
           </>
-        ) : (
+        ) : auth.authConfigured ? (
           <DropdownMenuItem onClick={onSignIn} disabled={auth.offline}>
             <Icon name="log-out" size={15} className="rotate-180" /> Log in
           </DropdownMenuItem>
-        )}
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/portal/src/mobile/screens.tsx
+++ b/apps/portal/src/mobile/screens.tsx
@@ -2,8 +2,16 @@ import { useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icons";
 import { FileIcon } from "@/components/file-icon";
 import { PersonAvatar, AvatarGroup } from "@/components/person-avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
-import { listFiles, listShared, type SpaceView } from "@/lib/api";
+import { listFiles, listShared, type Me, type SpaceView } from "@/lib/api";
 import { PLUGIN_CATALOG, STORAGE, type FileItem, type FileKind } from "@/lib/mock-data";
 
 function SectionHeader({ title, onMore }: { title: string; onMore?: () => void }) {
@@ -73,20 +81,76 @@ const ACTIVITY = [
   { who: "Maya", action: "renamed", target: "Family photos", when: "Yesterday" },
 ];
 
+// Tappable avatar that opens an account menu. Mirrors the desktop topbar: a real
+// signed-in user gets name/email + Sign out; logged out gets a Log in entry and
+// no fabricated persona (the green "online" dot is only shown when signed in).
+function AccountMenu({
+  userName,
+  auth,
+  onSignIn,
+  onSignOut,
+}: {
+  userName: string;
+  auth: Me;
+  onSignIn: () => void;
+  onSignOut: () => void;
+}) {
+  const user = auth.user;
+  const name = user?.name ?? user?.email?.split("@")[0] ?? userName;
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button aria-label="Account" className="relative shrink-0 rounded-full">
+          <PersonAvatar name={user ? name : "?"} size="lg" />
+          {user && (
+            <span className="absolute -right-0.5 -top-0.5 size-[11px] rounded-full bg-primary ring-2 ring-background" />
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        {user ? (
+          <>
+            <DropdownMenuLabel>
+              <div className="font-medium">{name}</div>
+              {user.email && (
+                <div className="text-[12px] font-normal text-muted-foreground">{user.email}</div>
+              )}
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={onSignOut}>
+              <Icon name="log-out" size={15} /> Sign out
+            </DropdownMenuItem>
+          </>
+        ) : (
+          <DropdownMenuItem onClick={onSignIn} disabled={auth.offline}>
+            <Icon name="log-out" size={15} className="rotate-180" /> Log in
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export function HomeScreen({
   userName,
+  auth,
   spaceCount,
   installed,
   refreshKey,
   onOpenFile,
   onNav,
+  onSignIn,
+  onSignOut,
 }: {
   userName: string;
+  auth: Me;
   spaceCount: number;
   installed: string[];
   refreshKey: number;
   onOpenFile: (f: FileItem) => void;
   onNav: (view: string) => void;
+  onSignIn: () => void;
+  onSignOut: () => void;
 }) {
   const [recent, setRecent] = useState<FileItem[]>([]);
   useEffect(() => {
@@ -107,10 +171,7 @@ export function HomeScreen({
           <div className="truncate text-[13px] font-medium text-muted-foreground">{greeting()}</div>
           <div className="truncate text-[28px] font-semibold leading-tight tracking-tight">{userName}</div>
         </div>
-        <div className="relative">
-          <PersonAvatar name={userName} size="lg" />
-          <span className="absolute -right-0.5 -top-0.5 size-[11px] rounded-full bg-primary ring-2 ring-background" />
-        </div>
+        <AccountMenu userName={userName} auth={auth} onSignIn={onSignIn} onSignOut={onSignOut} />
       </div>
 
       <div className="mb-5">

--- a/apps/portal/src/plugins/documentation-view.tsx
+++ b/apps/portal/src/plugins/documentation-view.tsx
@@ -1,4 +1,4 @@
-import { Fragment, isValidElement, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, isValidElement, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { cn } from "@canopy/ui";
@@ -75,6 +75,7 @@ const PLUGIN_GROUPS: { label: string; slugs: string[] }[] = [
     label: "File viewers & editors",
     slugs: ["plugin-image-viewer", "plugin-pdf-viewer", "plugin-markdown-editor", "plugin-univer-office", "plugin-code-editor"],
   },
+  { label: "Model & API editor", slugs: ["plugin-model-editor"] },
 ];
 const PLUGINS_OVERVIEW_SLUG = "built-in-plugins";
 
@@ -160,6 +161,39 @@ function Mermaid({ code }: { code: string }) {
       // svg is produced by mermaid with securityLevel:"strict" (sanitized).
       dangerouslySetInnerHTML={{ __html: svg }}
     />
+  );
+}
+
+/** A doc link that deep-links into the app's drive rather than to another doc page —
+ *  e.g. "open this model file in the Model Editor". Used for query-only hrefs like
+ *  `?space=connector:github&path=examples/specs/petstore&open=main.tsp`. A connected
+ *  space's file ids are assigned at index time, so the target file is resolved live by
+ *  (`path`, `open`) and handed to the app as a `?file=<id>` URL it opens on load. With
+ *  no JS — or on a miss — the plain href still browses the folder. */
+function DocAppLink({ href, children }: { href: string; children?: ReactNode }) {
+  const host = usePluginHost();
+  async function onClick(e: ReactMouseEvent) {
+    const params = new URLSearchParams(href.replace(/^\?/, ""));
+    const space = params.get("space") ?? "";
+    const dir = params.get("path") ?? "";
+    const open = params.get("open") ?? ""; // a filename within `dir` to open in its viewer
+    if (!space || !open) return; // a plain folder link — let the browser navigate
+    e.preventDefault();
+    const next = new URLSearchParams();
+    next.set("space", space);
+    if (dir) next.set("path", dir);
+    try {
+      const file = (await host.listFiles(dir, space)).find((f) => f.name === open);
+      if (file) next.set("file", file.id); // open it; else just land in the folder
+    } catch {
+      // ignore — fall back to browsing the folder
+    }
+    window.location.search = next.toString(); // full navigation; the app opens it on load
+  }
+  return (
+    <a href={href} onClick={onClick}>
+      {children}
+    </a>
   );
 }
 
@@ -264,6 +298,11 @@ export function DocumentationView() {
               {children}
             </a>
           );
+        }
+        // A deep link into the app itself (query-only, e.g. open a model file from a
+        // connected space in its viewer) — never a doc-to-doc link, so it sits here.
+        if (href?.startsWith("?")) {
+          return <DocAppLink href={href}>{children}</DocAppLink>;
         }
         if (href && /^(https?:|mailto:|#)/i.test(href)) {
           const external = /^https?:/i.test(href);

--- a/documentation/03-how-plugins-work.md
+++ b/documentation/03-how-plugins-work.md
@@ -438,8 +438,12 @@ identical for everyone. What differs is the **render half** — and there are no
     `HostBridge` and `usePluginTheme()` for light/dark, instead of importing `@/lib/api` or wiring
     its own `.dark` observer. The app implements the bridge once
     (`apps/portal/src/plugins/host-bridge.ts`) and provides it via `<PluginHostProvider>`. Swapping
-    that one implementation is what would let the same view run in a different host (e.g. a VS Code
-    webview). The SDK also ships the generic, schema-driven `PluginSettingsDialog` (it reaches
+    that one implementation is what lets the same view run in a different host — and the
+    [Model Editor](plugin-model-editor) already does: its `@canopy/model-editor` view runs unchanged
+    in the portal, in a [VS Code extension](plugin-model-editor) (bridge over webview `postMessage`),
+    and in a backend-free [standalone app](plugin-model-editor) (bridge over the File System Access
+    API). Same view, three hosts, three bridges — the portability the SDK boundary buys, shipped. The
+    SDK also ships the generic, schema-driven `PluginSettingsDialog` (it reaches
     settings I/O through the bridge, so any plugin can offer settings).
   - **`@canopy/ui`** — the shared component library. Views import shadcn primitives, the `Icon`
     set, `cn`, `toast`, and shared host components like `PersonAvatar` from `@canopy/ui` (used by

--- a/documentation/05-writing-a-plugin.md
+++ b/documentation/05-writing-a-plugin.md
@@ -123,7 +123,12 @@ renders it in the content area. That's the whole plugin.
 > rather than reaching into `@/lib/api`, `@/plugins/host`, or `@/components/ui/*`. The Model Editor
 > is the reference, with a lint rule enforcing the boundary on `src/components/model-editor/**`.
 > Keeping a view on the SDK is what makes it swappable to a sandboxed runtime — or another host
-> entirely (e.g. a VS Code webview) — by reimplementing the bridge, not the view.
+> entirely — by reimplementing the bridge, not the view. The Model Editor does exactly this today:
+> the same `@canopy/model-editor` component tree runs in the Canopy portal, as a
+> [VS Code extension](plugin-model-editor) (`apps/vscode-model-editor`, bridge over webview
+> `postMessage`), and as a backend-free [standalone web app](plugin-model-editor)
+> (`apps/model-editor-demo`, bridge over the File System Access API) — three hosts, one view, three
+> `HostBridge` implementations.
 
 ## A data-source plugin (GitHub)
 

--- a/documentation/11-built-in-plugins.md
+++ b/documentation/11-built-in-plugins.md
@@ -47,6 +47,20 @@ Two different switches, depending on the plugin:
 | [Univer Office](plugin-univer-office) | Spreadsheets (CSV/TSV) and Univer documents |
 | [Code Editor](plugin-code-editor) | Source code, with the VS Code editor (Monaco) |
 
+## Model & API editor
+
+| Plugin | Handles |
+|---|---|
+| [Model Editor](plugin-model-editor) | `.prisma` (ER/schema), `.tsp` (TypeSpec), `.arazzo` (workflows), `.asyncapi` (events) |
+
+Unlike the sandboxed viewers above, the **Model Editor** is a *trusted first-party* file editor —
+it ships as React in `PLUGIN_UI`, reaching the host only through the `@canopy/plugin-sdk`
+`HostBridge`. That discipline makes it Canopy's clearest **proof of the architecture's
+flexibility**: the exact same `@canopy/model-editor` view runs in three different hosts, each just
+reimplementing the bridge — the Canopy portal, a [VS Code extension](plugin-model-editor)
+(`apps/vscode-model-editor`), and a backend-free [standalone web app](plugin-model-editor)
+(`apps/model-editor-demo`). One view, three hosts, three bridges.
+
 ## Search (⌘K)
 
 A **⌘K / Ctrl-K command palette** searches files by name, content, and AI labels and jumps to a

--- a/documentation/design-relationship-intelligence.md
+++ b/documentation/design-relationship-intelligence.md
@@ -1,0 +1,238 @@
+# Design: Relationship intelligence (knowledge graph)
+
+> **Status:** design notes, not built. A future plugin plus a few core primitives.
+> This page captures a design conversation so the ideas aren't lost. Treat it as an RFC,
+> not documentation of shipped behaviour.
+
+## The idea
+
+An entity/relationship intelligence layer — people, companies, clients, competitors, and
+**how they tie together** — built from your own documents, emails, and files. A prior
+standalone version of this got messy fast. The bet here is that **Canopy is the plumbing
+layer that version was missing**, so the rebuild ships as a plugin and spends its effort on
+the genuinely hard problems instead of re-inventing storage and ingestion.
+
+It is *not* a CRM clone. CRM is one expression of this; the platform stays general. See
+[What belongs in the core](04-what-belongs-in-the-core).
+
+## Why the standalone version rotted
+
+Three failure modes, all at the plumbing layer:
+
+- **Schema churn** — entity and edge types never stop evolving; rigid schema cracks,
+  free-form turns to mush.
+- **Ingestion sprawl** — every source has its own shape; per-source parsers get tangled
+  into storage.
+- **No provenance** — a fact with no "where/when did this come from, is it stale" rots
+  into untrustworthy soup.
+
+Canopy already factors these out: the connector/adapter pattern handles ingestion, the
+[Model editor](plugin-model-editor) handles evolving schema, and the slim-core + plugin
+split keeps storage from tangling.
+
+## Core principle: store claims, derive facts
+
+The spine of the whole design. **Never store an AI-extracted value as a fact.** Store it as
+a **claim**, and let "facts" be *derived views* computed over the claim set.
+
+A claim is a triple plus metadata:
+
+```
+(subject, predicate, object)
+  + source_ref          -- exact indexed span the claim came from
+  + confidence          -- see "confidence is not one number" below
+  + extracted_by        -- model + version
+  + valid_time          -- when it was true in the world (e.g. a bill's issue date)
+  + ingest_time         -- when we learned it
+  + status              -- unverified | confirmed | contradicted
+```
+
+This is RDF-star semantics (metadata *on the statement*). Consequences:
+
+- **Demotion is free.** New evidence just changes the computed answer — no rollback, no
+  lost history.
+- **Proofreading is a click.** `source_ref` points at the highlighted span; re-extract when
+  models improve.
+- **Tasks are just another claim type** — email/doc → task uses the same pipeline (extract →
+  claim → human approves → derive).
+
+### Don't run a triple store
+
+Model claims as a **relational table in D1**, traversed with recursive CTEs (already proven
+to work). You get RDF-star expressiveness without the operational tax of a triple store or
+SPARQL — and the [Model editor](plugin-model-editor) can export the SQL.
+
+## Confidence is not one number
+
+"Confidence" bundles four orthogonal signals; keep them separate, because promotion is a
+function of all four:
+
+- **Extraction confidence** — did the AI read the value correctly?
+- **Source trust** — a government bill ≫ an email signature line.
+- **Corroboration** — how many *independent* sources agree?
+- **Recency / valid time** — when was it true?
+
+A high-extraction-confidence read of a two-year-old bill is still stale.
+
+## Bitemporality: error vs. change
+
+The hard case is contradiction — two bills, two different addresses. Did the data go wrong,
+or did the person move? Two timestamps per claim make this mechanical:
+
+- **valid_time** — true-in-the-world date (the document's own date).
+- **ingest_time** — when we learned it.
+
+Then:
+
+- Conflict at the **same valid time** → **error** (flag for review).
+- Conflict at **different valid times** → **change** (supersession; close the old interval,
+  open a new one).
+
+### Per-predicate semantics
+
+How a conflict is interpreted depends on the predicate, so the predicate vocabulary carries:
+
+- **Cardinality** — single (one current address) vs. multi (phone numbers coexist).
+- **Temporality** — *immutable* (birthdate: a conflict is **always** an error, dates
+  irrelevant) / *interval* (address: cross-time conflict = supersession) / *point-in-time*.
+
+### Reconcile is deterministic, not the LLM
+
+When a claim lands, classify it against existing `(subject, predicate)` claims:
+
+- **corroborates** → bump confidence
+- **supersedes** (newer valid time, single cardinality) → close old interval, open new
+- **contradicts** (same valid period) → review queue
+- **historical** (older valid time) → just store
+
+The AI *extracts* (value + as-of date + confidence). The **classification is rules**, so it
+is auditable and the human only ever sees genuine same-period contradictions.
+
+### Promotion policy (per predicate)
+
+Auto-promote to fact when corroborated by **≥2 independent trusted sources**, *or* a single
+source with **trust ≥ T and extraction ≥ C** and **no same-period conflict**. Everything else
+goes to the review queue.
+
+## Ontology: adopt, don't invent
+
+Layered vocabulary — an always-on **core pack** plus opt-in **domain/locale packs**.
+
+- **Adopt [schema.org](https://schema.org)** for the core (`Person`, `Organization`,
+  `PostalAddress`, `email`, `telephone`). Domain packs start from existing standards too
+  (FIBO for finance, HL7/FHIR for healthcare).
+- **Base "concepts" are typed value-objects, not nodes.** `email` / `phone` / `address` /
+  `national-id` carry **validators + normalizers + match rules** (phone → E.164, etc.). Those
+  matchers *are* the identity-resolution substrate (dedup) and the corroboration engine
+  (cross-document agreement). The definition earns its keep by shipping the matcher, not the
+  name.
+- **Packs ship as plugins** contributing vocabulary via model-spec — reuse the manifest +
+  [Model editor](plugin-model-editor) machinery. Versioned, namespaced (`schema:email` vs
+  `pack:field`), with alias→canonical mapping.
+- **AI generates pack *candidates*; a human promotes a versioned release.** Never mint
+  ad-hoc predicates per document at ingest — that is the vocabulary-sprawl death. A generated
+  pack must satisfy the contract: per-predicate cardinality + temporality, per-value-type
+  validator/normalizer/matcher.
+
+Flags:
+
+- **National-id is locale-specific** (US SSN ≠ Swedish personnummer ≠ org-nr) → locale packs,
+  not the global core.
+- **Your strongest match keys are your biggest liability.** SSN/personnummer/email make dedup
+  easy *and* make the store a GDPR/PII hotspot. Decide value-type sensitivity tagging early;
+  consider hash-for-matching over plaintext.
+
+## Storage & isolation: one D1 per space
+
+D1 is explicitly designed for "per-user, per-tenant or per-entity databases," so **one
+database per space** is the blessed pattern, delivered via **Workers for Platforms** (each
+space's user Worker carries its own D1 binding, which also sidesteps D1's static-binding
+limit).
+
+Verified Workers Paid limits: **50,000 databases per account** (raisable to millions), **10
+GB hard cap per database**, **1 TB account storage**, single-threaded **~1000 queries/s** per
+database. Per-space sharding is *good* for the graph — it keeps each one small, so recursive
+CTE traversal stays fast.
+
+Two things this commits you to:
+
+- **The per-space-vs-global decision.** You cannot JOIN across D1 databases, so a per-space DB
+  makes the shard boundary a hard query boundary. Cross-space "how it all ties together"
+  (the same person across spaces) needs a separate **global identity/edge index** above the
+  per-space DBs. Decide this first — it shapes everything.
+- **Migration fan-out.** A churny schema × tens of thousands of DBs needs an idempotent,
+  resumable migration runner built early. Don't adopt Workers for Platforms *solely* to shard
+  DBs — justify it via per-space plugin isolation, then get per-space D1 for free.
+
+## Consistency: D1 is master, search follows
+
+D1 `batch()` is a single SQLite transaction (all-or-nothing). That splits the sync problem:
+
+- **In-DB FTS5 (today): no dual-write problem.** Put the base-table write and the FTS upsert
+  in the **same `batch()`**. Atomicity is free; the only way to break it is to update the
+  index in a separate call.
+- **External search (Vectorize, later): a real dual-write.** Outbox and Workflows solve
+  *different halves*:
+  - **Outbox = capture.** Write the change record in the same `batch()` as the data.
+  - **Workflows/Queues = delivery.** Durable, retrying application to the external index.
+  - **Trap:** never trigger a Workflow from the write path — the commit→trigger gap drops on
+    isolate death. Drive the consumer from the committed log/cursor.
+
+**You already own the outbox.** The offline-mirror per-space monotonic `seq` +
+`/api/changes` feed *is* a changelog (see [Sharing and spaces](08-sharing-and-spaces)).
+Search is just another consumer with its own cursor. The one correctness check that matters:
+**is the `seq` write in the same `batch()` as the mutation?** If yes, nothing can be lost.
+
+Backstops: idempotent apply keyed by `(entity_id, seq)` (at-least-once is then safe), and a
+scheduled reconcile sweep diffing D1 vs. index to catch drift the outbox can't.
+
+## Core primitives worth lifting from micro.so
+
+[micro.so](https://www.micro.so) is a closed, vertical AI CRM. We keep its scope as a plugin,
+but two of its patterns belong in **Canopy core** because every plugin benefits:
+
+1. **Proposals inbox (highest leverage).** A host-provided "AI proposes → human approves"
+   surface any plugin can post to (proposal = source span + confidence + suggested action +
+   accept/dismiss). Build once; claim-promotion *and* task-generation both flow through it.
+2. **Assistant command surface.** A portal-wide command bar + assistant that plugins
+   contribute actions and context to via the plugin SDK. This is what makes Canopy feel like
+   one product instead of a folder of plugins.
+
+Plus **cross-space natural-language search** over the existing FTS5 index (NL → structured
+query now; semantic ranking once Vectorize lands).
+
+Plugin-level ideas from the same source: self-updating records (the claims pipeline),
+relationship-strength scoring (a derived view — needs interaction events as a first-class
+type), typed extraction templates per source, and mobile-first quick capture.
+
+**Do not** absorb micro's CRM scope into the core. Core stays the platform; CRM stays a
+plugin.
+
+## The two hard problems Canopy won't hand you
+
+Everything above is plumbing the platform provides. These two are yours to solve, and they
+are the same problem seen twice:
+
+- **Identity resolution / dedup** — "is this the same person across sources?" A triple is only
+  as good as the entity IDs in it; bad dedup gives a pristine graph of duplicates. The
+  value-type matchers are the substrate; the resolution logic on top is the work.
+- **Semantic graph discovery** — "how does it all tie together" beyond exact matches. Needs
+  **Vectorize** (currently deferred).
+
+## Suggested sequencing
+
+1. **Claims + core-pack schema** in the [Model editor](plugin-model-editor) — the foundation
+   everything else embeds. Model the core pack first (Person/Org/Place + value types with
+   their matchers).
+2. **Proposals inbox** — cheap, high-leverage, unblocks the approve loop for both
+   claim-promotion and task-generation.
+3. **Vectorize** — the first real enhancement, once there are entities/claims worth embedding.
+   Embed *entities* (name + aliases + key attributes), not just document chunks, so semantic
+   dedup works. Turning it on is also when the external-search consumer (above) goes live.
+
+## See also
+
+- [What belongs in the core](04-what-belongs-in-the-core) — the core-vs-plugin decision rule.
+- [Model editor](plugin-model-editor) — where the claims + ontology schema gets modelled.
+- [Sharing and spaces](08-sharing-and-spaces) — the `seq` change feed reused as the outbox.
+- [Tasks](plugin-tasks) — the existing task view this would feed with extracted tasks.

--- a/documentation/plugin-model-editor.md
+++ b/documentation/plugin-model-editor.md
@@ -1,0 +1,61 @@
+# Model Editor
+
+Opens data-model and API files in a visual editor instead of plain text — and, more than any other
+plugin, shows how far the Canopy plugin boundary travels.
+
+## What it does
+
+The Model Editor renders the files that describe an app's shape as interactive canvases rather than
+source text:
+
+| File type | Editor |
+| --- | --- |
+| `.prisma` | Visual Prisma schema / ER editor |
+| `.tsp` | TypeSpec entities + endpoints |
+| `.arazzo`, `.arazzo.yaml/.yml/.json` | Arazzo workflow builder |
+| `.asyncapi`, `.asyncapi.yaml/.yml/.json` | AsyncAPI channels (events) |
+
+Edits round-trip back to the file. In the portal it opens from the file preview surface; it also
+runs as a library-style scratch editor that persists models to `localStorage`.
+
+## One view, three hosts
+
+The Model Editor is the reference example of the [plugin SDK boundary](how-plugins-work). It's a
+*trusted first-party* view, but it still reaches its host only through the `@canopy/plugin-sdk`
+`HostBridge` (file I/O, AI, theme) — never app internals. An ESLint rule enforces that on
+`src/components/model-editor/**`.
+
+Because the view depends on nothing but the bridge, the **exact same `@canopy/model-editor`
+component tree runs in three different hosts** — each one just reimplements the bridge:
+
+- **Canopy portal** — the bridge talks to the Canopy API (`apps/portal/src/plugins/host-bridge.ts`).
+- **VS Code extension** (`apps/vscode-model-editor`) — a `CustomTextEditorProvider` owns the
+  `TextDocument`; the bridge proxies file reads/writes over webview `postMessage`, and
+  `host.aiGenerate` is wired to VS Code's Language Model API (Copilot). Ships as
+  `canopy-model-editor.vsix`.
+- **Standalone demo** (`apps/model-editor-demo`) — a backend-free web app where the bridge runs over
+  the browser's File System Access API, editing a real folder on disk. No server, no Canopy backend.
+
+Same view, three hosts, three `HostBridge` implementations. That's the portability the SDK boundary
+buys, shipped rather than hypothetical.
+
+> **Try it live →** [Open `main.tsp` in the Model Editor](?space=connector:github&path=examples/specs/petstore&open=main.tsp)
+> — this opens a real TypeSpec file from Canopy's own repo, mounted as a read-only
+> [GitHub-connected space](architecture). Two plugins working together: the GitHub connector
+> mounts the repo as a browsable space, and the Model Editor opens the spec on its canvas. No sign-in
+> needed — both are available to demo visitors.
+
+## At a glance
+
+- **Type:** File editor (trusted first-party React, registered as a `FileView` in `PLUGIN_UI`)
+- **Contributes:** a file view for `.prisma` / `.tsp` / `.arazzo` / `.asyncapi`
+- **Capabilities:** file read/write and AI generation, via the `HostBridge`
+- **Boundary:** `@canopy/plugin-sdk` only, lint-enforced on `src/components/model-editor/**`
+- **Also runs as:** a VS Code extension (`apps/vscode-model-editor`) and a backend-free standalone
+  app (`apps/model-editor-demo`)
+
+## See also
+
+- [How plugins work](how-plugins-work) — the trust tiers and the `HostBridge` capability model.
+- [Writing a plugin](writing-a-plugin) — why keeping a view on the SDK makes it host-portable.
+- [Built-in plugins](built-in-plugins) — the rest of what ships with Canopy.

--- a/packages/core/src/ai.ts
+++ b/packages/core/src/ai.ts
@@ -20,6 +20,8 @@ export interface AiModel {
   provider: string;
   /** True when it accepts inline image (and, where supported, document) input, not just text. */
   vision?: boolean;
+  /** One-line "what it's good for", shown beneath the label in a picker. Optional. */
+  description?: string;
 }
 
 /** One part of a message: plain text, or an inline binary (image / PDF) the model reads. */

--- a/packages/model-editor/src/spec/discover.ts
+++ b/packages/model-editor/src/spec/discover.ts
@@ -73,10 +73,15 @@ export async function discoverProject(
   const openapi = new Map<string, TextFile>();
   const asyncapi = new Map<string, TextFile>();
 
-  // Seed with the opened file so discovery works even before anything is read.
-  if (isTsp(opened.name)) tsp.set(opened.name, { id: opened.id, name: opened.name, path: opened.path, text: opened.text });
-  else if (isArazzo(opened.name)) arazzo.set(opened.name, { id: opened.id, name: opened.name, path: opened.path, text: opened.text });
-  else if (isAsyncApi(opened.name)) asyncapi.set(opened.name, { id: opened.id, name: opened.name, path: opened.path, text: opened.text });
+  // Seed with the opened file so discovery works even before anything is read. The
+  // opened file is excluded from the sibling read below, so it has to be classified
+  // here — including OpenAPI/AsyncAPI YAML/JSON, which are detected by name or by
+  // sniffing the body (sniff AsyncAPI before OpenAPI, mirroring the sibling pass).
+  const openedFile = { id: opened.id, name: opened.name, path: opened.path, text: opened.text };
+  if (isTsp(opened.name)) tsp.set(opened.name, openedFile);
+  else if (isArazzo(opened.name)) arazzo.set(opened.name, openedFile);
+  else if (isAsyncApi(opened.name) || (isYamlOrJson(opened.name) && (looksLikeAsyncApi(opened.name) || sniffAsyncApi(opened.text)))) asyncapi.set(opened.name, openedFile);
+  else if (isYamlOrJson(opened.name) && (looksLikeOpenApi(opened.name) || sniffOpenApi(opened.text))) openapi.set(opened.name, openedFile);
 
   const reads = provider.siblings
     .filter((ref) => isTsp(ref.name) || isArazzo(ref.name) || isAsyncApi(ref.name) || isYamlOrJson(ref.name))

--- a/packages/model-editor/src/spec/discover.ts
+++ b/packages/model-editor/src/spec/discover.ts
@@ -41,6 +41,25 @@ const sniffAsyncApi = (text: string) => /^\s*("?asyncapi"?\s*:)/m.test(text);
 
 const toTextFile = (ref: SpecFileRef, text: string): TextFile => ({ id: ref.id, name: ref.name, path: ref.path, text });
 
+// Well-known JSON/YAML files that live next to specs but are never one. We skip them so
+// opening a spec in a real project folder doesn't read (and sniff) the package manifest,
+// tsconfig, lockfile, or tool rc files just to discard them. A real OpenAPI/AsyncAPI doc
+// is never named any of these, and the layout sidecar is explicitly kept.
+const NOISE_NAMES = new Set([
+  "package.json", "package-lock.json", "components.json", "turbo.json", "nx.json", "vercel.json",
+  "biome.json", "renovate.json", "pnpm-workspace.yaml", "pnpm-lock.yaml", "yarn.lock", "bun.lockb",
+]);
+const isNoiseFile = (name: string): boolean => {
+  const lower = name.toLowerCase();
+  if (lower === SIDECAR_NAME.toLowerCase()) return false; // the layout sidecar is wanted
+  return (
+    NOISE_NAMES.has(lower) ||
+    /^[jt]sconfig(\.[^/]+)?\.json$/.test(lower) || // tsconfig.json, tsconfig.build.json, jsconfig.json
+    /^\.[^/]+rc(\.(json|ya?ml))?$/.test(lower) || // .eslintrc, .prettierrc.json, .babelrc, …
+    lower.endsWith(".tsbuildinfo")
+  );
+};
+
 /**
  * Assemble the related file set for an opened spec file. The opened file's text is
  * passed in directly (it may hold unsaved edits) and overrides its drive copy.
@@ -62,6 +81,7 @@ export async function discoverProject(
   const reads = provider.siblings
     .filter((ref) => isTsp(ref.name) || isArazzo(ref.name) || isAsyncApi(ref.name) || isYamlOrJson(ref.name))
     .filter((ref) => ref.name !== opened.name) // opened file already seeded
+    .filter((ref) => !isNoiseFile(ref.name)) // skip package.json / tsconfig / lockfiles / rc files
     .map(async (ref) => {
       try {
         return { ref, text: await provider.readText(ref) };

--- a/packages/model-editor/src/spec/spec-file-viewer.tsx
+++ b/packages/model-editor/src/spec/spec-file-viewer.tsx
@@ -43,20 +43,33 @@ export function SpecFileViewer({ fileId, fileName, spaceId, filePath }: FileView
     let alive = true;
     setGraph(null);
     setError(null);
+    const space = spaceId;
     (async () => {
       const text = await host.readFileText(fileId);
+      const opened = { id: fileId, name: fileName, path: filePath, text };
 
       // Resolve the containing folder + space so we can list sibling files. For a
       // FileItem, `path` is already the containing directory (not the full file path),
       // both from a listing and from getFile — so use it as-is. Fall back to a metadata
       // lookup only when the host didn't hand us a path (e.g. a `?file=` deep link).
-      const space = spaceId;
       let dir = filePath ?? "";
       if (filePath == null) {
         const meta = await host.getFile(fileId);
         if (meta) dir = meta.path ?? "";
       }
 
+      // ── Phase 1: render the opened file on its own, before touching the folder. ──
+      // This is the file the user actually opened, so show it immediately instead of
+      // blocking the first paint on listing + reading every sibling in the directory.
+      const seed = await buildProjectGraph(await discoverProject(opened, { siblings: [], readText: () => Promise.resolve("") }));
+      if (!alive) return;
+      // Key layout by the project folder so positions are stable across reloads and
+      // shared by every file opened in the same folder.
+      setProjectKey(`${space ?? "personal"}|${dir}`);
+      setProject({ dir, space });
+      setGraph(seed);
+
+      // ── Phase 2: scan the folder for related files and merge the full graph. ──
       let siblings = await host.listFiles(dir, space).catch(() => []);
       // Safety net: if the opened file isn't in the listed folder, our directory was
       // wrong — re-resolve it from metadata and relist. Keeps discovery working even if
@@ -73,15 +86,12 @@ export function SpecFileViewer({ fileId, fileName, spaceId, filePath }: FileView
         .filter((f) => f.kind !== "folder")
         .map((f) => ({ id: f.id, name: f.name, path: f.path ?? "" }));
 
-      const files = await discoverProject({ id: fileId, name: fileName, path: filePath, text }, { siblings: refs, readText: (r) => host.readFileText(r.id) });
+      const files = await discoverProject(opened, { siblings: refs, readText: (r) => host.readFileText(r.id) });
       const built = await buildProjectGraph(files);
-      if (alive) {
-        // Key layout by the project folder so positions are stable across reloads and
-        // shared by every file opened in the same folder.
-        setProjectKey(`${space ?? "personal"}|${dir}`);
-        setProject({ dir, space });
-        setGraph(built);
-      }
+      if (!alive) return;
+      setProjectKey(`${space ?? "personal"}|${dir}`);
+      setProject({ dir, space });
+      setGraph(built);
     })().catch((e) => alive && setError(e instanceof Error ? e.message : "Failed to load"));
 
     return () => {

--- a/packages/model-editor/src/spec/spec-file-viewer.tsx
+++ b/packages/model-editor/src/spec/spec-file-viewer.tsx
@@ -63,10 +63,11 @@ export function SpecFileViewer({ fileId, fileName, spaceId, filePath }: FileView
       // blocking the first paint on listing + reading every sibling in the directory.
       const seed = await buildProjectGraph(await discoverProject(opened, { siblings: [], readText: () => Promise.resolve("") }));
       if (!alive) return;
-      // Key layout by the project folder so positions are stable across reloads and
-      // shared by every file opened in the same folder.
-      setProjectKey(`${space ?? "personal"}|${dir}`);
-      setProject({ dir, space });
+      // Paint the opened file immediately, but hold off on publishing `projectKey`/
+      // `project`: the directory below is still provisional (the fallback may correct
+      // it), and those drive the layout namespace + commit target. Publishing them now
+      // would let a drag/commit during this window land in the wrong folder. Phase 2
+      // sets them once `dir` is final.
       setGraph(seed);
 
       // ── Phase 2: scan the folder for related files and merge the full graph. ──

--- a/packages/store/src/files.test.ts
+++ b/packages/store/src/files.test.ts
@@ -103,6 +103,28 @@ describe("FileService over libsql", () => {
     expect(versions[0]!.n).toBe(1);
   });
 
+  it("rename updates the name column without a new version or losing metadata", async () => {
+    const f = await upload("old.md", "# hi", { metadata: { tag: "x" } });
+    const before = f.currentVersionId;
+
+    const renamed = await svc.patchMetadata({ sub: USER }, f.id, { name: "new.md" });
+    expect(renamed.name).toBe("new.md");
+    expect(renamed.metadata.tag).toBe("x"); // metadata survives
+    expect(renamed.metadata.name).toBeUndefined(); // name lands on the column, not the blob
+    expect(renamed.currentVersionId).toBe(before);
+
+    const versions = await db.all<{ n: number }>("SELECT COUNT(*) AS n FROM file_versions WHERE file_id = ?", [f.id]);
+    expect(versions[0]!.n).toBe(1);
+  });
+
+  it("rejects an empty name or one with a path separator", async () => {
+    const f = await upload("doc.md", "# hi");
+    await expect(svc.patchMetadata({ sub: USER }, f.id, { name: "  " })).rejects.toThrow();
+    await expect(svc.patchMetadata({ sub: USER }, f.id, { name: "a/b.md" })).rejects.toThrow();
+    const still = await svc.getFile({ sub: USER }, f.id);
+    expect(still.name).toBe("doc.md");
+  });
+
   it("rapid same-author edits coalesce into one version, keep metadata, and release the old blob", async () => {
     const f = await upload("notes.md", "v1", { path: "Docs", metadata: { tag: "keep" } });
     const v1Key = f.version!.blobKey!;

--- a/packages/store/src/files.ts
+++ b/packages/store/src/files.ts
@@ -1398,12 +1398,29 @@ export class FileService {
     return this.enrichForDisplay(rows.map(joinedToFileWithVersion));
   }
 
-  /** Merge into the metadata JSON. Does NOT create a new version. Requires editor+. */
+  /**
+   * Merge into the metadata JSON. Does NOT create a new version. Requires editor+.
+   *
+   * A `name` key is the one exception that lands on a real column (the file's
+   * display name) rather than in the metadata blob — so rename rides the same
+   * path as star/tags/move without inventing a separate endpoint.
+   */
   async patchMetadata(caller: Caller, id: string, patch: Record<string, unknown>): Promise<FileWithVersion> {
     const file = await this.requirePerm(caller, id, "editor");
-    const metadata = { ...file.metadata, ...patch };
-    if ("path" in patch) metadata.path = normPath(String(patch.path ?? ""));
-    await this.db.run("UPDATE files SET metadata = ?, updated_at = ? WHERE id = ?", [
+    const { name: namePatch, ...metaPatch } = patch;
+    const metadata = { ...file.metadata, ...metaPatch };
+    if ("path" in metaPatch) metadata.path = normPath(String(metaPatch.path ?? ""));
+
+    // Validate a rename: a non-empty name with no path separators (the name is a
+    // single segment; moving lives on `metadata.path`).
+    let name = file.name;
+    if ("name" in patch) {
+      name = String(namePatch ?? "").trim();
+      if (!name || name.includes("/") || name.includes("\\")) throw new Error("invalid file name");
+    }
+
+    await this.db.run("UPDATE files SET name = ?, metadata = ?, updated_at = ? WHERE id = ?", [
+      name,
       JSON.stringify(metadata),
       new Date().toISOString(),
       id,
@@ -1929,6 +1946,30 @@ export class FileService {
       await this.indexFileDoc(file, body);
     } catch (err) {
       console.warn(`[search] reindex failed for ${fileId}: ${(err as Error).message}`);
+    }
+  }
+
+  /** Re-run text extraction + search indexing for a single file — the user-facing
+   *  "Reprocess" action. A managed blob re-extracts inline (the same path every
+   *  mutation takes). An external file is re-pulled from its connector and its
+   *  cached extract (`content_ref`) refreshed, so a source whose bytes changed
+   *  out-of-band becomes searchable again without waiting for the next reconcile.
+   *  Editor on the file is required. (AI document processors are re-run separately
+   *  by the API, off the response path — they need the gateway, not the store.) */
+  async reprocess(caller: Caller, id: string): Promise<void> {
+    const file = await this.requirePerm(caller, id, "editor");
+    const version = file.currentVersionId ? await this.loadVersion(file.currentVersionId) : null;
+    if (version?.source === "external") {
+      const text = await this.extractExternalText(file, version);
+      const contentRef = text ? `extract/${file.id}.txt` : version.contentRef ?? null;
+      if (text && contentRef) await this.store.put(contentRef, new TextEncoder().encode(text));
+      await this.db.run("UPDATE file_versions SET extract_state = 'done', content_ref = ? WHERE id = ?", [
+        contentRef,
+        version.id,
+      ]);
+      await this.indexFileDoc(file, text ?? undefined);
+    } else {
+      await this.reindex(id);
     }
   }
 

--- a/packages/store/src/files.ts
+++ b/packages/store/src/files.ts
@@ -1967,7 +1967,11 @@ export class FileService {
         contentRef,
         version.id,
       ]);
-      await this.indexFileDoc(file, text ?? undefined);
+      // Only index the freshly extracted text. If extraction produced nothing,
+      // fall back to reindex(id) so the cached content_ref body is preserved
+      // rather than wiping the doc down to title/metadata.
+      if (text) await this.indexFileDoc(file, text);
+      else await this.reindex(id);
     } else {
       await this.reindex(id);
     }

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -9,6 +9,7 @@ export * from "./schema";
 export * from "./retention";
 export * from "./cache";
 export * from "./search";
+export * from "./search-ai";
 export * from "./repo";
 export * from "./authz";
 export * from "./users";

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -471,6 +471,24 @@ export const MIGRATIONS: { version: number; statements: string[] }[] = [
       `ALTER TABLE spaces ADD COLUMN version_days INTEGER`, // retained-day window when policy = 'days'
     ],
   },
+  {
+    // AI Search item map. The Cloudflare AI Search Items API keys writes by name
+    // (we use the fileId) but `items.delete()` and `items.get()` take the opaque
+    // `id` the API *returns* from `upload()` — there is no delete-by-name and no
+    // way to look an item up by its key. So we persist fileId → itemId here on
+    // every upload, then resolve it back to delete the item (on file delete, or
+    // when a file's body disappears). Best-effort hygiene only: the authoritative
+    // ACL/liveness gate is still the by-id files lookup in `aiQuery`, so a missing
+    // row never surfaces a file the caller can't read — it just risks an orphaned
+    // chunk in the index. See packages/store/src/search-ai.ts.
+    version: 22,
+    statements: [
+      `CREATE TABLE IF NOT EXISTS ai_search_items (
+         file_id TEXT PRIMARY KEY,
+         item_id TEXT NOT NULL
+       )`,
+    ],
+  },
 ];
 
 /** Apply any migrations newer than what's recorded. Safe to call on every boot. */

--- a/packages/store/src/search-ai.test.ts
+++ b/packages/store/src/search-ai.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { createLibsqlDb } from "./db-libsql";
+import { runMigrations } from "./schema";
+import { createSqlSearchIndex } from "./search";
+import { createAiSearchIndex, type AiSearchInstance, type AiSearchResponse } from "./search-ai";
+import type { Db } from "./db";
+
+/**
+ * The hybrid AI Search adapter (Items-API push model), run against a real
+ * in-memory libsql engine (so the fileId → file lookup and the FTS5 leg are
+ * both real) with a stubbed AI Search instance standing in for the Cloudflare
+ * binding. We assert the parts unique to this adapter: the feed pushes through
+ * the Items API, hits resolve to current files, ACL + liveness are enforced by
+ * the DB lookup (not the metadata filter), and the two legs fuse.
+ */
+const SPACE_A = "space-a";
+const SPACE_B = "space-b";
+const ALL = { spaceIds: [SPACE_A, SPACE_B] };
+
+/** Insert a file row (the unit the fileId lookup resolves). */
+async function addFile(
+  db: Db,
+  opts: { id: string; tenant: string; name: string; metadata?: Record<string, unknown>; deleted?: boolean },
+) {
+  const now = "2026-01-01T00:00:00.000Z";
+  await db.run(
+    `INSERT INTO files (id, tenant_id, owner_id, name, current_version_id, metadata, created_at, updated_at, deleted_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [opts.id, opts.tenant, "owner", opts.name, null, JSON.stringify(opts.metadata ?? {}), now, now, opts.deleted ? now : null],
+  );
+}
+
+/** A stub AI Search instance: returns the configured chunks and records feed calls. */
+function stubInstance(response: AiSearchResponse) {
+  const state = {
+    lastFilters: undefined as unknown,
+    uploads: [] as { name: string; content: string; metadata?: Record<string, unknown> }[],
+    deletes: [] as string[],
+  };
+  const instance: AiSearchInstance = {
+    async search(req) {
+      state.lastFilters = req.ai_search_options?.retrieval?.filters;
+      return response;
+    },
+    items: {
+      async upload(name, content, opts) {
+        state.uploads.push({ name, content, metadata: opts?.metadata });
+        return { id: name };
+      },
+      async delete(id) {
+        state.deletes.push(id);
+        return {};
+      },
+    },
+  };
+  return { instance, state };
+}
+
+describe("createAiSearchIndex (hybrid, Items-API push)", () => {
+  let db: Db;
+
+  beforeEach(async () => {
+    db = createLibsqlDb(":memory:");
+    await runMigrations(db);
+  });
+
+  it("resolves an AI Search chunk (by fileId) to its current file row", async () => {
+    await addFile(db, { id: "f1", tenant: SPACE_A, name: "contract.pdf", metadata: { path: "/legal/contract.pdf" } });
+    const fts = createSqlSearchIndex(db);
+    const { instance } = stubInstance({
+      chunks: [{ score: 0.9, text: "the agreement was signed on...", item: { key: "f1" } }],
+    });
+    const index = createAiSearchIndex({ db, instance, fts });
+
+    const { items } = await index.query({ text: "agreement" }, ALL);
+    expect(items.map((i) => i.id)).toEqual(["f1"]);
+    expect(items[0]).toMatchObject({ spaceId: SPACE_A, title: "contract.pdf", kind: "file", path: "/legal/contract.pdf" });
+    expect(items[0]!.snippet).toContain("agreement");
+  });
+
+  it("enforces ACL via the DB lookup even if AI Search returns out-of-scope hits", async () => {
+    await addFile(db, { id: "fa", tenant: SPACE_A, name: "mine.pdf" });
+    await addFile(db, { id: "fb", tenant: SPACE_B, name: "theirs.pdf" });
+    const fts = createSqlSearchIndex(db);
+    // Backend leaks a SPACE_B hit; the DB lookup must drop it when scope is SPACE_A only.
+    const { instance } = stubInstance({
+      chunks: [
+        { score: 0.9, text: "...", item: { key: "fb" } },
+        { score: 0.8, text: "...", item: { key: "fa" } },
+      ],
+    });
+    const index = createAiSearchIndex({ db, instance, fts });
+
+    const { items } = await index.query({ text: "anything" }, { spaceIds: [SPACE_A] });
+    expect(items.map((i) => i.id)).toEqual(["fa"]);
+  });
+
+  it("drops soft-deleted files even if AI Search still has them", async () => {
+    await addFile(db, { id: "gone", tenant: SPACE_A, name: "old.pdf", deleted: true });
+    const fts = createSqlSearchIndex(db);
+    const { instance } = stubInstance({ chunks: [{ score: 0.9, text: "...", item: { key: "gone" } }] });
+    const index = createAiSearchIndex({ db, instance, fts });
+
+    const { items } = await index.query({ text: "anything" }, ALL);
+    expect(items).toEqual([]);
+  });
+
+  it("sends a scoped spaceId metadata filter to AI Search", async () => {
+    const fts = createSqlSearchIndex(db);
+    const { instance, state } = stubInstance({ chunks: [] });
+    const index = createAiSearchIndex({ db, instance, fts });
+
+    await index.query({ text: "q" }, { spaceIds: [SPACE_A] });
+    expect(state.lastFilters).toEqual({ spaceId: SPACE_A });
+    await index.query({ text: "q" }, ALL);
+    expect(state.lastFilters).toEqual({ spaceId: { $in: [SPACE_A, SPACE_B] } });
+  });
+
+  it("fuses FTS (filename) and AI Search (content) recall", async () => {
+    await addFile(db, { id: "byname", tenant: SPACE_A, name: "quarterly budget.xlsx" });
+    await addFile(db, { id: "bycontent", tenant: SPACE_A, name: "notes.txt" });
+    const fts = createSqlSearchIndex(db);
+    await fts.upsert({ id: "byname", spaceId: SPACE_A, title: "quarterly budget.xlsx", kind: "file" });
+    const { instance } = stubInstance({
+      chunks: [{ score: 0.95, text: "the budget figures for Q3", item: { key: "bycontent" } }],
+    });
+    const index = createAiSearchIndex({ db, instance, fts });
+
+    const { items } = await index.query({ text: "budget" }, ALL);
+    expect(items.map((i) => i.id).sort()).toEqual(["byname", "bycontent"].sort());
+  });
+
+  it("degrades to FTS-only when AI Search throws", async () => {
+    await addFile(db, { id: "f1", tenant: SPACE_A, name: "report.txt" });
+    const fts = createSqlSearchIndex(db);
+    await fts.upsert({ id: "f1", spaceId: SPACE_A, title: "annual report", kind: "file" });
+    const instance: AiSearchInstance = {
+      async search() {
+        throw new Error("binding unavailable");
+      },
+      items: { async upload() {}, async delete() {} },
+    };
+    const index = createAiSearchIndex({ db, instance, fts });
+
+    const { items } = await index.query({ text: "annual" }, ALL);
+    expect(items.map((i) => i.id)).toEqual(["f1"]);
+  });
+
+  it("reads the legacy response shape (data[] + attributes.file.key)", async () => {
+    await addFile(db, { id: "f1", tenant: SPACE_A, name: "old.pdf" });
+    const fts = createSqlSearchIndex(db);
+    const { instance } = stubInstance({
+      data: [{ score: 0.7, content: "legacy chunk text", attributes: { file: { key: "f1" } } }],
+    });
+    const index = createAiSearchIndex({ db, instance, fts });
+
+    const { items } = await index.query({ text: "legacy" }, ALL);
+    expect(items.map((i) => i.id)).toEqual(["f1"]);
+    expect(items[0]!.snippet).toBe("legacy chunk text");
+  });
+
+  it("excludes the AI leg when the caller restricts to non-file kinds", async () => {
+    await addFile(db, { id: "f1", tenant: SPACE_A, name: "doc.pdf" });
+    const fts = createSqlSearchIndex(db);
+    const { instance } = stubInstance({ chunks: [{ score: 0.9, text: "...", item: { key: "f1" } }] });
+    const index = createAiSearchIndex({ db, instance, fts });
+
+    const { items } = await index.query({ text: "doc", kinds: ["folder"] }, ALL);
+    expect(items).toEqual([]);
+  });
+
+  it("upsert pushes content-bearing docs to the Items API and feeds FTS", async () => {
+    const fts = createSqlSearchIndex(db);
+    const { instance, state } = stubInstance({ chunks: [] });
+    const index = createAiSearchIndex({ db, instance, fts });
+
+    await index.upsert({ id: "1", spaceId: SPACE_A, title: "via hybrid", text: "body content here", kind: "file" });
+    expect(state.uploads).toHaveLength(1);
+    expect(state.uploads[0]).toMatchObject({ name: "1", metadata: { spaceId: SPACE_A } });
+    expect(state.uploads[0]!.content).toContain("body content here");
+    expect((await fts.query({ text: "hybrid" }, ALL)).items.map((i) => i.id)).toEqual(["1"]);
+  });
+
+  it("upsert skips the AI leg for title-only docs (nothing to embed)", async () => {
+    const fts = createSqlSearchIndex(db);
+    const { instance, state } = stubInstance({ chunks: [] });
+    const index = createAiSearchIndex({ db, instance, fts });
+
+    await index.upsert({ id: "fld", spaceId: SPACE_A, title: "My Folder", kind: "folder" });
+    expect(state.uploads).toEqual([]);
+    // Still indexed lexically.
+    expect((await fts.query({ text: "folder" }, ALL)).items.map((i) => i.id)).toEqual(["fld"]);
+  });
+
+  it("delete removes from both the Items API and FTS", async () => {
+    const fts = createSqlSearchIndex(db);
+    const { instance, state } = stubInstance({ chunks: [] });
+    const index = createAiSearchIndex({ db, instance, fts });
+
+    await index.upsert({ id: "1", spaceId: SPACE_A, title: "doomed", text: "to be deleted", kind: "file" });
+    await index.delete("1");
+    expect(state.deletes).toEqual(["1"]);
+    expect((await fts.query({ text: "doomed" }, ALL)).items).toEqual([]);
+  });
+});

--- a/packages/store/src/search-ai.test.ts
+++ b/packages/store/src/search-ai.test.ts
@@ -45,7 +45,9 @@ function stubInstance(response: AiSearchResponse) {
     items: {
       async upload(name, content, opts) {
         state.uploads.push({ name, content, metadata: opts?.metadata });
-        return { id: name };
+        // The real Items API mints an opaque id distinct from the upload name —
+        // model that so tests catch any delete-by-name regression.
+        return { id: `item-${name}`, key: name };
       },
       async delete(id) {
         state.deletes.push(id);
@@ -138,7 +140,7 @@ describe("createAiSearchIndex (hybrid, Items-API push)", () => {
       async search() {
         throw new Error("binding unavailable");
       },
-      items: { async upload() {}, async delete() {} },
+      items: { async upload(name) { return { id: `item-${name}` }; }, async delete() {} },
     };
     const index = createAiSearchIndex({ db, instance, fts });
 
@@ -192,14 +194,29 @@ describe("createAiSearchIndex (hybrid, Items-API push)", () => {
     expect((await fts.query({ text: "folder" }, ALL)).items.map((i) => i.id)).toEqual(["fld"]);
   });
 
-  it("delete removes from both the Items API and FTS", async () => {
+  it("delete removes from both the Items API (by returned itemId) and FTS", async () => {
     const fts = createSqlSearchIndex(db);
     const { instance, state } = stubInstance({ chunks: [] });
     const index = createAiSearchIndex({ db, instance, fts });
 
     await index.upsert({ id: "1", spaceId: SPACE_A, title: "doomed", text: "to be deleted", kind: "file" });
     await index.delete("1");
-    expect(state.deletes).toEqual(["1"]);
+    // Deletes by the opaque itemId minted at upload, not the fileId/upload key.
+    expect(state.deletes).toEqual(["item-1"]);
     expect((await fts.query({ text: "doomed" }, ALL)).items).toEqual([]);
+  });
+
+  it("purges the AI item when a re-upsert leaves the doc body empty", async () => {
+    const fts = createSqlSearchIndex(db);
+    const { instance, state } = stubInstance({ chunks: [] });
+    const index = createAiSearchIndex({ db, instance, fts });
+
+    await index.upsert({ id: "1", spaceId: SPACE_A, title: "report", text: "annual figures", kind: "file" });
+    expect(state.uploads).toHaveLength(1);
+    // Body removed (e.g. content cleared / extraction failed): the prior item
+    // must be deleted so stale chunks can't keep producing hits.
+    await index.upsert({ id: "1", spaceId: SPACE_A, title: "report", text: "", kind: "file" });
+    expect(state.deletes).toEqual(["item-1"]);
+    expect(state.uploads).toHaveLength(1); // no re-upload of an empty body
   });
 });

--- a/packages/store/src/search-ai.ts
+++ b/packages/store/src/search-ai.ts
@@ -97,6 +97,11 @@ export function createAiSearchIndex(opts: AiSearchIndexOptions) {
         aiQuery(db, instance, query, scope, limit),
       ]);
 
+      // AI contributed nothing (no hits, or it degraded to empty): return the
+      // FTS page untouched. Fusing here would needlessly remap FTS's own scores
+      // onto an RRF scale and drop its cursor — for no ranking benefit.
+      if (aiHits.length === 0) return ftsPage;
+
       // Reciprocal-rank fusion: a doc's fused score is the sum of 1/(k+rank)
       // across the lists it appears in, so agreement between the two backends
       // floats a hit to the top without needing comparable raw scores.
@@ -202,14 +207,22 @@ async function aiQuery(
   // soft-deleted. This is the authoritative ACL + liveness boundary (the AI-side
   // metadata filter above is only a cost/recall optimization on top).
   const ids = [...byId.keys()];
-  const rows = await db.all<FileRow>(
-    `SELECT id, tenant_id AS spaceId, name AS title, updated_at AS modifiedAt, metadata
-       FROM files
-      WHERE id IN (${ids.map(() => "?").join(",")})
-        AND tenant_id IN (${scope.spaceIds.map(() => "?").join(",")})
-        AND deleted_at IS NULL`,
-    [...ids, ...scope.spaceIds],
-  );
+  let rows: FileRow[];
+  try {
+    rows = await db.all<FileRow>(
+      `SELECT id, tenant_id AS spaceId, name AS title, updated_at AS modifiedAt, metadata
+         FROM files
+        WHERE id IN (${ids.map(() => "?").join(",")})
+          AND tenant_id IN (${scope.spaceIds.map(() => "?").join(",")})
+          AND deleted_at IS NULL`,
+      [...ids, ...scope.spaceIds],
+    );
+  } catch (err) {
+    // Best-effort, like the search call above: a resolution failure drops the AI
+    // leg to empty rather than rejecting the whole (FTS-backed) search.
+    console.warn(`[search] ai-search hit resolution failed: ${(err as Error).message}`);
+    return [];
+  }
 
   const hits: { hit: SearchHit; order: number }[] = [];
   for (const r of rows) {

--- a/packages/store/src/search-ai.ts
+++ b/packages/store/src/search-ai.ts
@@ -1,0 +1,391 @@
+import type { Db } from "./db";
+
+/**
+ * A hybrid {@link SearchIndex} backed by Cloudflare AI Search (formerly AutoRAG)
+ * for semantic *content* relevance, fused with the SQL/D1 FTS5 index
+ * ({@link createSqlSearchIndex}) for *lexical* (filename / exact-term / metadata)
+ * matching.
+ *
+ * Indexing is **push-based and source-independent**: rather than pointing AI
+ * Search at an R2 bucket and letting it scan, we feed it through its Items API
+ * from the same trusted in-process feed that drives FTS. So `upsert(doc)` uploads
+ * the *composed* text (filename + extracted body + description + labels + tags —
+ * exactly what FTS sees) and `delete(id)` removes it, for every file regardless
+ * of where its bytes live (R2 blob, GitHub, Synology…). That means: AI Search
+ * sees canopy's curated text (not just raw bytes), connector-backed spaces are
+ * covered uniformly, indexing is per-item (no multi-hour bucket-scan lag), and
+ * hits carry our own `fileId` back — no blob-key reverse-map.
+ *
+ * Access control is layered. Every query is sent with a `spaceId` metadata
+ * filter so AI Search only retrieves the caller's spaces, but the authoritative
+ * boundary is the by-id DB lookup in `aiQuery`: it re-checks `tenant_id` against
+ * the scope and drops anything soft-deleted, so a stale or mis-filtered AI hit
+ * can never surface a file the caller can't (currently) read. The same lookup
+ * supplies the always-current title/path/modifiedAt for display.
+ *
+ * The two legs fuse with reciprocal-rank fusion (their raw scores aren't
+ * comparable). The AI leg is best-effort throughout: an upload, delete, or query
+ * failure degrades to FTS-only and never fails the operation — FTS remains the
+ * source of truth for freshness and lexical recall.
+ *
+ * Structurally implements `@canopy/core`'s `SearchIndex` (kept import-free so
+ * the store stays core-independent); the host wires it into the `SearchIndex`
+ * slot where TS structural typing checks the shapes line up.
+ */
+export function createAiSearchIndex(opts: AiSearchIndexOptions) {
+  const { db, instance, fts } = opts;
+
+  return {
+    async upsert(docs: SearchDoc | SearchDoc[]): Promise<void> {
+      const list = Array.isArray(docs) ? docs : [docs];
+      if (list.length === 0) return;
+      // FTS is the lexical leg + zero-lag freshness; always fed, authoritative.
+      await fts.upsert(list);
+      // Push content-bearing docs to AI Search for semantic recall. Title-only
+      // docs (e.g. folders, or files whose body hasn't been extracted yet) add
+      // nothing to embed — they'll be (re)uploaded once a body exists. Best-effort.
+      await Promise.all(
+        list
+          .filter((d) => d.text)
+          .map(async (d) => {
+            try {
+              const content = [d.title, d.text].filter(Boolean).join("\n");
+              // Upsert by name: re-feeding the same id replaces the prior item.
+              await instance.items.upload(d.id, content, { metadata: { spaceId: d.spaceId } });
+            } catch (err) {
+              console.warn(`[search] ai-search upload failed for ${d.id}: ${(err as Error).message}`);
+            }
+          }),
+      );
+    },
+
+    async delete(ids: string | string[]): Promise<void> {
+      const list = Array.isArray(ids) ? ids : [ids];
+      if (list.length === 0) return;
+      await fts.delete(list);
+      // Best-effort index hygiene only: the by-id liveness check in `aiQuery`
+      // already prevents a deleted file from surfacing even if this never runs.
+      await Promise.all(
+        list.map(async (id) => {
+          try {
+            await instance.items.delete(id);
+          } catch (err) {
+            console.warn(`[search] ai-search delete failed for ${id}: ${(err as Error).message}`);
+          }
+        }),
+      );
+    },
+
+    async query(query: SearchQuery, scope: SearchScope): Promise<Page<SearchHit>> {
+      if (scope.spaceIds.length === 0) return { items: [] };
+      const limit = clampLimit(query.limit);
+
+      // Both backends in parallel; a flaky AI Search call degrades to FTS-only
+      // rather than failing the search (see `aiQuery`'s try/catch).
+      const [ftsPage, aiHits] = await Promise.all([
+        fts.query(query, scope),
+        aiQuery(db, instance, query, scope, limit),
+      ]);
+
+      // Reciprocal-rank fusion: a doc's fused score is the sum of 1/(k+rank)
+      // across the lists it appears in, so agreement between the two backends
+      // floats a hit to the top without needing comparable raw scores.
+      const fused = new Map<string, { hit: SearchHit; score: number }>();
+      const fuse = (hits: SearchHit[]) => {
+        hits.forEach((hit, i) => {
+          const add = 1 / (RRF_K + i + 1);
+          const prev = fused.get(hit.id);
+          if (prev) {
+            prev.score += add;
+            // Prefer a snippet from whichever backend produced one (AI Search's
+            // is a content chunk; FTS's is a title/metadata excerpt).
+            if (!prev.hit.snippet && hit.snippet) prev.hit.snippet = hit.snippet;
+          } else {
+            fused.set(hit.id, { hit: { ...hit }, score: add });
+          }
+        });
+      };
+      fuse(ftsPage.items);
+      fuse(aiHits);
+
+      const items = [...fused.values()]
+        .sort((a, b) => b.score - a.score)
+        .slice(0, limit)
+        .map(({ hit, score }) => ({ ...hit, score }));
+
+      // No cursor: a fused ranking over two backends with no shared offset model
+      // isn't stably pageable. Callers raise `limit` instead of paging.
+      return { items };
+    },
+  };
+}
+
+export type AiSearchIndex = ReturnType<typeof createAiSearchIndex>;
+
+export interface AiSearchIndexOptions {
+  /** Metadata DB: resolves AI Search hits (by fileId) → current file rows, and
+   *  is the authoritative ACL + liveness boundary. */
+  db: Db;
+  /** The Cloudflare AI Search instance binding (e.g. `env.AI_SEARCH.get(name)`). */
+  instance: AiSearchInstance;
+  /** The SQL/D1 FTS index — the lexical leg and source of truth for freshness. */
+  fts: SearchIndex;
+}
+
+/**
+ * Run the AI Search leg: semantic query → resolve hit fileIds → current,
+ * in-scope, live file rows (the authoritative ACL/liveness gate + display data).
+ */
+async function aiQuery(
+  db: Db,
+  instance: AiSearchInstance,
+  query: SearchQuery,
+  scope: SearchScope,
+  limit: number,
+): Promise<SearchHit[]> {
+  // The AI leg indexes content-bearing files only. If the caller restricts to
+  // other kinds (e.g. ["folder"]), it can't contribute.
+  if (query.kinds?.length && !query.kinds.includes("file")) return [];
+  if (!query.text.trim()) return [];
+
+  let res: AiSearchResponse;
+  try {
+    res = await instance.search({
+      query: query.text,
+      ai_search_options: {
+        retrieval: {
+          // Over-fetch a little: chunks dedupe to fewer files, and some may be
+          // dropped by the liveness/scope gate, so ask for more than `limit`.
+          max_num_results: Math.min(AI_MAX_RESULTS, Math.max(limit * 3, limit)),
+          filters: scopeFilter(scope),
+        },
+      },
+    });
+  } catch (err) {
+    // Best-effort: a search hiccup degrades to FTS-only, never fails the query.
+    console.warn(`[search] ai-search query failed: ${(err as Error).message}`);
+    return [];
+  }
+
+  // The AI Search response shape has shifted across versions (chunks/data,
+  // item/attributes) — read defensively.
+  const chunks = res.chunks ?? res.data ?? [];
+  if (chunks.length === 0) return [];
+
+  // Keep the best-scoring chunk per file id, preserving first-seen order so the
+  // backend's own ranking carries into the RRF rank.
+  const byId = new Map<string, { score: number; snippet?: string; order: number }>();
+  let order = 0;
+  for (const c of chunks) {
+    const id = chunkFileId(c);
+    if (!id) continue;
+    const score = typeof c.score === "number" ? c.score : 0;
+    const snippet = chunkText(c);
+    const prev = byId.get(id);
+    if (!prev) byId.set(id, { score, snippet, order: order++ });
+    else if (score > prev.score) byId.set(id, { score, snippet: snippet ?? prev.snippet, order: prev.order });
+  }
+  if (byId.size === 0) return [];
+
+  // Resolve fileIds → current file rows, scoped to the caller's spaces and not
+  // soft-deleted. This is the authoritative ACL + liveness boundary (the AI-side
+  // metadata filter above is only a cost/recall optimization on top).
+  const ids = [...byId.keys()];
+  const rows = await db.all<FileRow>(
+    `SELECT id, tenant_id AS spaceId, name AS title, updated_at AS modifiedAt, metadata
+       FROM files
+      WHERE id IN (${ids.map(() => "?").join(",")})
+        AND tenant_id IN (${scope.spaceIds.map(() => "?").join(",")})
+        AND deleted_at IS NULL`,
+    [...ids, ...scope.spaceIds],
+  );
+
+  const hits: { hit: SearchHit; order: number }[] = [];
+  for (const r of rows) {
+    const m = byId.get(r.id);
+    if (!m) continue;
+    const meta = parseMeta(r.metadata);
+    // Mirror the FTS adapter's equality filter over indexed metadata fields.
+    if (!matchesFilter(meta, query.filter)) continue;
+    hits.push({
+      order: m.order,
+      hit: {
+        id: r.id,
+        spaceId: r.spaceId,
+        score: m.score,
+        title: r.title,
+        snippet: m.snippet,
+        kind: "file",
+        path: typeof meta.path === "string" ? meta.path : undefined,
+        modifiedAt: r.modifiedAt ?? undefined,
+      },
+    });
+  }
+  return hits.sort((a, b) => a.order - b.order).map((h) => h.hit);
+}
+
+/**
+ * Restrict AI Search to the caller's spaces via the `spaceId` custom-metadata
+ * field we stamp on every uploaded item. Vectorize-style `$in` (the current AI
+ * Search filter format). Purely an optimization — the DB lookup is what enforces
+ * ACL — so if the backend ignores or rejects it, results are still scoped.
+ *
+ * Note: `spaceId` must be declared as a custom metadata attribute on the AI
+ * Search instance for the filter to apply.
+ */
+function scopeFilter(scope: SearchScope): Record<string, unknown> {
+  return scope.spaceIds.length === 1 ? { spaceId: scope.spaceIds[0] } : { spaceId: { $in: scope.spaceIds } };
+}
+
+/** Our uploaded item name is the file id; read it back defensively across shapes. */
+function chunkFileId(c: AiSearchChunk): string | undefined {
+  return (
+    c.item?.key ??
+    c.attributes?.file?.key ??
+    c.filename ??
+    (typeof c.item?.metadata?.fileId === "string" ? c.item.metadata.fileId : undefined) ??
+    undefined
+  );
+}
+
+function chunkText(c: AiSearchChunk): string | undefined {
+  if (typeof c.text === "string" && c.text) return c.text;
+  if (typeof c.content === "string" && c.content) return c.content;
+  if (Array.isArray(c.content)) {
+    const joined = c.content.map((p) => p?.text ?? "").filter(Boolean).join(" ");
+    if (joined) return joined;
+  }
+  return undefined;
+}
+
+function parseMeta(raw: string | null): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const v = JSON.parse(raw);
+    return v && typeof v === "object" ? (v as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function matchesFilter(meta: Record<string, unknown>, filter?: Record<string, unknown>): boolean {
+  for (const [key, value] of Object.entries(filter ?? {})) {
+    if (meta[key] !== value) return false;
+  }
+  return true;
+}
+
+const RRF_K = 60;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+const AI_MAX_RESULTS = 50; // AI Search `max_num_results` ceiling
+
+function clampLimit(limit?: number): number {
+  if (!limit || !Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(MAX_LIMIT, Math.floor(limit)));
+}
+
+/** Row shape from the fileId → file lookup. */
+interface FileRow {
+  id: string;
+  spaceId: string;
+  title: string;
+  modifiedAt: string | null;
+  metadata: string | null;
+}
+
+// --- Duck-typed slice of the Cloudflare AI Search binding ------------------
+// Kept structural (no @cloudflare/workers-types dep); the real binding —
+// `env.AI_SEARCH.get(name)` — satisfies it.
+
+/** A single AI Search instance: the `.search()` (retrieval) + `.items` (feed) surfaces we use. */
+export interface AiSearchInstance {
+  search(opts: AiSearchRequest): Promise<AiSearchResponse>;
+  items: AiSearchItems;
+}
+
+/** The built-in-storage Items API: push documents into the instance directly. */
+export interface AiSearchItems {
+  /** Upload (upsert) an item by name; `content` is the text to index. Queued for processing. */
+  upload(name: string, content: string, opts?: { metadata?: Record<string, unknown> }): Promise<unknown>;
+  /** Remove an item previously uploaded under `id`. */
+  delete(id: string): Promise<unknown>;
+}
+
+export interface AiSearchRequest {
+  query: string;
+  ai_search_options?: {
+    retrieval?: {
+      max_num_results?: number;
+      filters?: Record<string, unknown>;
+    };
+  };
+}
+
+export interface AiSearchResponse {
+  /** Current shape. */
+  chunks?: AiSearchChunk[];
+  /** Legacy shape (older AutoRAG API). */
+  data?: AiSearchChunk[];
+}
+
+export interface AiSearchChunk {
+  score?: number;
+  text?: string;
+  content?: string | { text?: string }[];
+  /** Current shape: the source object (its `key` is our uploaded item name = fileId). */
+  item?: { key?: string; metadata?: Record<string, unknown> };
+  /** Legacy shape: nested under attributes.file. */
+  attributes?: { file?: { key?: string } };
+  /** Oldest shape: bare filename/key. */
+  filename?: string;
+}
+
+// --- Structural mirror of `@canopy/core`'s SearchIndex types --------------
+// Duplicated (not imported) so this package stays core-independent.
+
+interface Page<T> {
+  items: T[];
+  cursor?: string;
+}
+
+interface SearchDoc {
+  id: string;
+  spaceId: string;
+  title: string;
+  text?: string;
+  kind?: string;
+  path?: string;
+  connectorId?: string;
+  modifiedAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface SearchQuery {
+  text: string;
+  kinds?: string[];
+  filter?: Record<string, unknown>;
+  limit?: number;
+  cursor?: string;
+}
+
+interface SearchScope {
+  spaceIds: string[];
+}
+
+interface SearchHit {
+  id: string;
+  spaceId: string;
+  score: number;
+  title: string;
+  snippet?: string;
+  kind?: string;
+  path?: string;
+  modifiedAt?: string;
+}
+
+interface SearchIndex {
+  upsert(docs: SearchDoc | SearchDoc[]): Promise<void>;
+  delete(ids: string | string[]): Promise<void>;
+  query(query: SearchQuery, scope: SearchScope): Promise<Page<SearchHit>>;
+}

--- a/packages/store/src/search-ai.ts
+++ b/packages/store/src/search-ai.ts
@@ -41,21 +41,31 @@ export function createAiSearchIndex(opts: AiSearchIndexOptions) {
       if (list.length === 0) return;
       // FTS is the lexical leg + zero-lag freshness; always fed, authoritative.
       await fts.upsert(list);
-      // Push content-bearing docs to AI Search for semantic recall. Title-only
-      // docs (e.g. folders, or files whose body hasn't been extracted yet) add
-      // nothing to embed — they'll be (re)uploaded once a body exists. Best-effort.
+      // Push content-bearing docs to AI Search for semantic recall. Best-effort.
       await Promise.all(
-        list
-          .filter((d) => d.text)
-          .map(async (d) => {
-            try {
-              const content = [d.title, d.text].filter(Boolean).join("\n");
-              // Upsert by name: re-feeding the same id replaces the prior item.
-              await instance.items.upload(d.id, content, { metadata: { spaceId: d.spaceId } });
-            } catch (err) {
-              console.warn(`[search] ai-search upload failed for ${d.id}: ${(err as Error).message}`);
+        list.map(async (d) => {
+          try {
+            // Only files with a body embed usefully. A title-only doc (a folder,
+            // or a file whose body hasn't been extracted yet — or was *removed*)
+            // must not stay in the index: purge any prior item so stale chunks
+            // can't keep producing hits/snippets after content disappears.
+            if (!d.text?.trim()) {
+              await deleteAiItem(db, instance, d.id);
+              return;
             }
-          }),
+            const content = [d.title, d.text].filter(Boolean).join("\n");
+            const prev = await getAiItemId(db, d.id);
+            const { id: itemId } = await instance.items.upload(d.id, content, {
+              metadata: { spaceId: d.spaceId },
+            });
+            await setAiItemId(db, d.id, itemId);
+            // The Items API keys by name but mints a fresh `id` per upload; if a
+            // re-upload didn't overwrite in place, drop the superseded item.
+            if (prev && prev !== itemId) await safeDelete(instance, prev);
+          } catch (err) {
+            console.warn(`[search] ai-search upload failed for ${d.id}: ${(err as Error).message}`);
+          }
+        }),
       );
     },
 
@@ -68,7 +78,7 @@ export function createAiSearchIndex(opts: AiSearchIndexOptions) {
       await Promise.all(
         list.map(async (id) => {
           try {
-            await instance.items.delete(id);
+            await deleteAiItem(db, instance, id);
           } catch (err) {
             console.warn(`[search] ai-search delete failed for ${id}: ${(err as Error).message}`);
           }
@@ -168,8 +178,9 @@ async function aiQuery(
   }
 
   // The AI Search response shape has shifted across versions (chunks/data,
-  // item/attributes) — read defensively.
-  const chunks = res.chunks ?? res.data ?? [];
+  // item/attributes) — read defensively. Guard the array type too: a malformed
+  // payload must degrade to FTS-only, not throw mid-iteration.
+  const chunks = Array.isArray(res.chunks) ? res.chunks : Array.isArray(res.data) ? res.data : [];
   if (chunks.length === 0) return [];
 
   // Keep the best-scoring chunk per file id, preserving first-seen order so the
@@ -275,6 +286,41 @@ function matchesFilter(meta: Record<string, unknown>, filter?: Record<string, un
   return true;
 }
 
+// --- AI Search item map (fileId → the opaque itemId `upload()` returns) -----
+// `items.delete()`/`items.get()` only accept that itemId — there is no
+// delete-by-name — so we persist it on upload and resolve it back here.
+
+async function getAiItemId(db: Db, fileId: string): Promise<string | undefined> {
+  const row = await db.first<{ item_id: string }>("SELECT item_id FROM ai_search_items WHERE file_id = ?", [fileId]);
+  return row?.item_id;
+}
+
+async function setAiItemId(db: Db, fileId: string, itemId: string): Promise<void> {
+  await db.run(
+    `INSERT INTO ai_search_items (file_id, item_id) VALUES (?, ?)
+       ON CONFLICT(file_id) DO UPDATE SET item_id = excluded.item_id`,
+    [fileId, itemId],
+  );
+}
+
+/** Delete the AI Search item mapped to `fileId` (if any) and drop the mapping. */
+async function deleteAiItem(db: Db, instance: AiSearchInstance, fileId: string): Promise<void> {
+  const itemId = await getAiItemId(db, fileId);
+  if (!itemId) return;
+  await safeDelete(instance, itemId);
+  await db.run("DELETE FROM ai_search_items WHERE file_id = ?", [fileId]);
+}
+
+/** Delete an item by its itemId, swallowing failure so cleanup stays idempotent
+ *  and best-effort (a stale chunk can't surface — `aiQuery` re-checks liveness). */
+async function safeDelete(instance: AiSearchInstance, itemId: string): Promise<void> {
+  try {
+    await instance.items.delete(itemId);
+  } catch (err) {
+    console.warn(`[search] ai-search item delete failed for ${itemId}: ${(err as Error).message}`);
+  }
+}
+
 const RRF_K = 60;
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
@@ -306,9 +352,10 @@ export interface AiSearchInstance {
 
 /** The built-in-storage Items API: push documents into the instance directly. */
 export interface AiSearchItems {
-  /** Upload (upsert) an item by name; `content` is the text to index. Queued for processing. */
-  upload(name: string, content: string, opts?: { metadata?: Record<string, unknown> }): Promise<unknown>;
-  /** Remove an item previously uploaded under `id`. */
+  /** Upload an item under `name` (we use the fileId); `content` is the text to
+   *  index. Returns the opaque `id` that `delete()`/`get()` require. Queued for processing. */
+  upload(name: string, content: string, opts?: { metadata?: Record<string, unknown> }): Promise<{ id: string; key?: string }>;
+  /** Remove an item by the `id` returned from {@link upload} (not the upload name). */
   delete(id: string): Promise<unknown>;
 }
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -54,12 +54,34 @@
 			"database_name": "canopy"
 		}
 	],
-	// Workers AI: the host AI gateway. With this bound, the deployment exposes its
-	// models (e.g. @cf/google/gemma-4-26b-a4b-it) to plugins with no per-user key —
-	// Document AI labels uploads out of the box. Edit the exposed list in src/ai/cloudflare.ts.
+	// Workers AI: the host AI gateway. With this bound, the deployment exposes a curated
+	// menu of models (Gemma 4 26B / Llama 4 Scout / Mistral Small for text+vision, Kimi
+	// K2.7 Code / GLM-5.2 / Qwen2.5 Coder for codegen+extraction, GPT-OSS 120B / Qwen3
+	// for strict-JSON categorization) to plugins with no per-user key — Document AI
+	// labels uploads out of the box. Edit the exposed list in src/ai/cloudflare.ts.
 	"ai": {
 		"binding": "AI"
 	},
+	// AI Search (semantic document search), OPTIONAL and OFF by default so the
+	// zero-setup "Deploy to Cloudflare" path keeps working. When both the binding
+	// below and the AI_SEARCH_INSTANCE var (in `vars`) are present, search becomes
+	// hybrid — Cloudflare AI Search for semantic recall fused with the always-on
+	// D1 FTS leg (filename / exact-term / metadata); otherwise it's FTS-only. The
+	// feed pushes each file's curated text via the Items API (source-independent,
+	// covers connector spaces too), and a by-id DB lookup is the ACL + liveness
+	// gate — see packages/store/src/search-ai.ts.
+	//
+	// To turn it on:
+	//   1. Provision an instance:  `wrangler ai-search create canopy-search`
+	//   2. On that instance, declare a custom metadata attribute named `spaceId`
+	//      (used as the per-space retrieval filter; the DB lookup is the backstop).
+	//   3. Uncomment the binding below AND set AI_SEARCH_INSTANCE in `vars`.
+	// "ai_search_namespaces": [
+	// 	{
+	// 		"binding": "AI_SEARCH",
+	// 		"namespace": "default"
+	// 	}
+	// ],
 	// Document-parser container: heavy PDF/spreadsheet parsing off the isolate, and
 	// the only way to reach a tailnet-only Synology source (a tsnet sidecar joins your
 	// tailnet — see apps/docworker). The Worker offloads to it whenever the DOCWORKER
@@ -145,6 +167,9 @@
 		"OIDC_ISSUER": "https://canopy.token.sesamy.dev",
 		"OIDC_CLIENT_ID": "canopy",
 		"OIDC_AUDIENCE": "urn:canopy"
+		// Name of the AI Search instance to query. Uncomment together with the
+		// "ai_search_namespaces" binding above to enable hybrid semantic search.
+		// "AI_SEARCH_INSTANCE": "canopy-search"
 	},
 	// Daily version-retention sweep: thins old snapshots to the retention curve (#11).
 	"triggers": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -166,7 +166,7 @@
 		"GITHUB_BRANCH": "main",
 		"OIDC_ISSUER": "https://canopy.token.sesamy.dev",
 		"OIDC_CLIENT_ID": "canopy",
-		"OIDC_AUDIENCE": "urn:canopy"
+		"OIDC_AUDIENCE": "urn:canopy",
 		// Name of the AI Search instance to query. Uncomment together with the
 		// "ai_search_namespaces" binding above to enable hybrid semantic search.
 		// "AI_SEARCH_INSTANCE": "canopy-search"


### PR DESCRIPTION
## What

Adds a hybrid `SearchIndex` backed by **Cloudflare AI Search** (semantic recall) fused with the existing **D1 FTS5** index (lexical / filename / metadata), behind the existing adapter seam. No changes to call sites, plugins, `/api/search`, or the MCP `search` tool — it's a drop-in backend selected per-environment.

## How it works

- **Push-based, source-independent indexing.** The trusted feed pushes each file's *composed* text (filename + extracted body + description + labels + tags) through the AI Search **Items API** — `upsert` → `items.upload`, `delete` → `items.delete`. So AI Search sees canopy's curated text (not just raw bytes), connector-backed spaces (GitHub/Synology) are covered uniformly, and indexing is per-item (no multi-hour bucket-scan lag).
- **ACL + liveness.** Queries send a `spaceId` metadata filter for efficiency, but the authoritative boundary is a by-id DB lookup that re-checks `tenant_id` against the caller's scope and drops soft-deleted rows — a stale or mis-filtered AI hit can never surface a file the caller can't read. The same lookup supplies current title/path/modifiedAt.
- **Fusion + resilience.** The FTS and AI legs fuse with reciprocal-rank fusion (their raw scores aren't comparable). The AI leg is best-effort throughout — any upload/delete/query failure degrades to FTS-only and never fails the operation.

## Scope

- Worker runtime only; **FTS5 stays the Node/dev default**.
- Gated on the `AI_SEARCH` binding + `AI_SEARCH_INSTANCE` var, both **commented off by default** in `wrangler.jsonc`, so the zero-setup "Deploy to Cloudflare" path is unaffected.

## Enabling (when ready)

1. `wrangler ai-search create canopy-search`
2. Declare a custom metadata attribute named `spaceId` on the instance.
3. Uncomment the `ai_search_namespaces` binding and set `AI_SEARCH_INSTANCE` in `vars`.

## Files

- `packages/store/src/search-ai.ts` — `createAiSearchIndex({ db, instance, fts })`
- `packages/store/src/search-ai.test.ts` — 11 cases (resolution, ACL/liveness, filter shape, fusion, degradation, legacy response shape, feed behavior)
- `apps/api/src/worker.ts` — select hybrid backend when the binding is present
- `wrangler.jsonc` — commented binding + setup guide

## Tests

`@canopy/store` and `@canopy/api` typecheck clean; all 153 store tests pass (11 new).

## Notes

- One detail I couldn't verify against a live binding: whether `items.upload` upserts by name and `items.delete` accepts our id (vs an internal item id). The code assumes both; if the real binding differs the FTS leg keeps results correct while it's adjusted — worth confirming on first deploy.
- The repo has no Changesets tooling, so no changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional hybrid search combining keyword (fast) and AI semantic search, with unified ranking for improved relevance.
  * Introduced file **Rename** and **Reprocess** actions (including a server endpoint to trigger async re-indexing/AI labeling).
  * Enhanced AI model picker details and added mobile sign-in/out menu support; expanded built-in Model/API editor documentation.
* **Bug Fixes**
  * Search safely degrades to keyword-only when AI search is unavailable.
  * Deleted or inaccessible items are no longer returned in results.
* **Tests**
  * Added integration coverage for hybrid AI search indexing and metadata patching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->