### PR TITLE
Scheduling core: owned JSCalendar calendars, events & tasks (#34)

### DIFF
--- a/apps/api/spec/main.tsp
+++ b/apps/api/spec/main.tsp
@@ -689,21 +689,93 @@ interface IntegrationsApi {
 }
 
 @route("/api/tasks")
-@useAuth(NoAuth)
 interface Tasks {
-  /** Tasks from the caller's configured source (or the demo default). */
+  /**
+   * Tasks the caller can see: owned tasks from the scheduling store plus any
+   * data-source provider's (GitHub). `?space=` scopes to one space.
+   */
   @get
+  @useAuth(NoAuth)
   @operationId("listTasks")
-  list(): TaskList | Error;
+  list(@query space?: string): TaskList | Error;
+
+  /** Create an owned task in a calendar. */
+  @post
+  @operationId("createTask")
+  create(@body body: CreateTask): {
+    @statusCode statusCode: 201;
+    @body created: Task;
+  } | Error;
+
+  /** Patch an owned task. */
+  @patch
+  @route("/{id}")
+  @operationId("updateTask")
+  update(@path id: string, @body body: UpdateTask): { updated: Task } | Error;
+
+  /** Soft-delete an owned task. */
+  @delete
+  @route("/{id}")
+  @operationId("deleteTask")
+  remove(@path id: string): Ok | Error;
 }
 
 @route("/api/calendar")
-@useAuth(NoAuth)
-interface Calendar {
-  /** Calendar events from the caller's configured source. `?from=`/`?to=` are ISO 8601. */
+interface CalendarFeed {
+  /**
+   * The aggregated calendar stream: owned events from the scheduling store plus
+   * any data-source provider's (GitHub), with the caller's owned calendars for the
+   * aggregator's calendar list. `?from=`/`?to=` are ISO 8601; `?space=` scopes.
+   */
   @get
+  @useAuth(NoAuth)
   @operationId("listCalendar")
-  list(@query from?: string, @query to?: string): CalendarList | Error;
+  list(@query from?: string, @query to?: string, @query space?: string): CalendarList | Error;
+}
+
+@route("/api/calendars")
+interface Calendars {
+  /** The caller's owned calendars (= virtual folders). `?space=` scopes to one space. */
+  @get
+  @operationId("listCalendars")
+  list(@query space?: string): CalendarsList | Error;
+
+  /** Create a calendar (a colored virtual folder) in a space. */
+  @post
+  @operationId("createCalendar")
+  create(@body body: CreateCalendar): {
+    @statusCode statusCode: 201;
+    @body created: Calendar;
+  } | Error;
+
+  /** Share a calendar (folder) with a person by email. */
+  @post
+  @route("/share")
+  @operationId("shareCalendar")
+  share(@body body: ShareCalendar): Ok | Error;
+}
+
+@route("/api/events")
+interface Events {
+  /** Create an event in a calendar. */
+  @post
+  @operationId("createEvent")
+  create(@body body: CreateEvent): {
+    @statusCode statusCode: 201;
+    @body created: Event;
+  } | Error;
+
+  /** Patch an event. */
+  @patch
+  @route("/{id}")
+  @operationId("updateEvent")
+  update(@path id: string, @body body: UpdateEvent): { updated: Event } | Error;
+
+  /** Soft-delete an event. */
+  @delete
+  @route("/{id}")
+  @operationId("deleteEvent")
+  remove(@path id: string): Ok | Error;
 }
 
 // ───────────────────────────── plugins ───────────────────────────────────────

--- a/apps/api/spec/models.tsp
+++ b/apps/api/spec/models.tsp
@@ -911,7 +911,11 @@ model Integrations {
   usingDefault: boolean;
 }
 
-/** A task surfaced by a data-source plugin. */
+/**
+ * A task in the flat view shape the Tasks plugin renders. Either surfaced by a
+ * data-source plugin (GitHub issues) or an owned task projected from the
+ * scheduling store (#34) — owned tasks carry their calendar coordinates.
+ */
 model Task {
   @key id: string;
   title: string;
@@ -921,15 +925,29 @@ model Task {
   labels?: string[];
   priority?: "low" | "normal" | "high";
   url?: string;
+  /** Owned tasks: the space the task lives in. */
+  spaceId?: string;
+  /** Owned tasks: the calendar (folder) path within the space. */
+  path?: string;
+  /** Owned tasks: the calendar id = `${spaceId}${path}`. */
+  calendarId?: string;
+  /** Owned tasks: whether the caller may edit it. */
+  editable?: boolean;
 }
 
-/** Tasks from the active source. */
+/** Tasks from the active source(s). */
 model TaskList {
+  /** Which sources contributed (e.g. "owned", "github", "owned+github"). */
   source?: string | null;
   tasks: Task[];
 }
 
-/** A calendar event surfaced by a data-source plugin. */
+/**
+ * A calendar event in the flat view shape the Calendar plugin renders. Either
+ * surfaced by a data-source plugin (GitHub milestones/releases) or an owned event
+ * projected from the scheduling store (#34) — owned events carry their calendar
+ * coordinates so the aggregator can group, color, and toggle by calendar.
+ */
 model CalendarEvent {
   @key id: string;
   title: string;
@@ -942,12 +960,160 @@ model CalendarEvent {
   url?: string;
   /** Accent token. */
   tone?: string;
+  /** Owned events: the space the event lives in. */
+  spaceId?: string;
+  /** Owned events: the calendar (folder) path within the space ("" = root). */
+  path?: string;
+  /** Owned events: the calendar id = `${spaceId}${path}`. */
+  calendarId?: string;
+  /** Owned events: the calendar's accent color (HSL triplet). */
+  color?: string;
+  /** Owned events: whether the caller may edit it. */
+  editable?: boolean;
 }
 
-/** Events from the active source. */
+/** Events from the active source(s), plus the caller's owned calendars. */
 model CalendarList {
+  /** Which sources contributed (e.g. "owned", "github", "owned+github"). */
   source?: string | null;
   events: CalendarEvent[];
+  /** The caller's owned calendars (= virtual folders), for the aggregator's calendar list. */
+  calendars?: Calendar[];
+}
+
+// ───────────────────────── scheduling (#34) ──────────────────────────────────
+// Owned scheduling entities, modeled on JSCalendar (RFC 8984). A *calendar is a
+// virtual folder*: it reuses the drive's `folders` table and folder-grant ACL, so
+// sharing a calendar is a folder grant and a space has 0–n calendars (+ an implicit
+// root calendar). Events and tasks live in their own tables (never `files`), each
+// carrying `spaceId` + `path` so one folder grant covers a folder's documents *and*
+// its scheduling items.
+
+/** A calendar: a shareable virtual folder of scheduling items. */
+model Calendar {
+  /** Stable id = `${spaceId}${path}` (the folder object id). */
+  @key id: string;
+  @extension("x-references", "Space")
+  spaceId: string;
+  /** Virtual-folder path within the space ("" = the implicit root calendar). */
+  path: string;
+  name: string;
+  /** Accent color — an HSL triplet like "212 92% 50%", or null to inherit the space color. */
+  color?: string | null;
+  /** The caller's effective role on this calendar (folder grant ∪ space membership). */
+  role: Role;
+  createdAt?: utcDateTime;
+}
+
+/** Fields to create a calendar (a colored virtual folder) in a space. */
+model CreateCalendar {
+  name: string;
+  /** Target space; omit for the caller's personal space. */
+  space?: string;
+  /** Folder path; defaults to a slug of `name`. */
+  path?: string;
+  color?: string | null;
+}
+
+/** A person principal — an identity hub events reference as a participant. */
+model Principal {
+  @key id: string;
+  @extension("x-references", "Space")
+  spaceId?: string | null;
+  kind: "person";
+  /** Links to a Canopy user when known. */
+  sub?: Sub | null;
+  email?: string | null;
+  name?: string | null;
+}
+
+/** An owned calendar event (JSCalendar-shaped record). */
+model Event {
+  @key id: string;
+  @extension("x-references", "Space")
+  spaceId: string;
+  /** The calendar (folder) path within the space. */
+  path: string;
+  /** JSCalendar logical identity (iCal UID). */
+  uid: string;
+  title: string;
+  /** ISO 8601 (date or date-time). */
+  start?: string | null;
+  /** ISO 8601; omit for point-in-time / all-day. */
+  end?: string | null;
+  allDay: boolean;
+  description?: string | null;
+  location?: string | null;
+  /** Tags (JSCalendar keywords) — classification only, no permission meaning. */
+  keywords: string[];
+  /** Content hash of the JSCalendar object. */
+  etag: string;
+  createdAt: utcDateTime;
+  updatedAt: utcDateTime;
+}
+
+/** Fields to create an event in a calendar. */
+model CreateEvent {
+  title: string;
+  /** Target space; omit for the caller's personal space. */
+  space?: string;
+  /** Calendar folder path ("" = the space's root calendar). */
+  path?: string;
+  start?: string;
+  end?: string;
+  allDay?: boolean;
+  description?: string;
+  location?: string;
+  keywords?: string[];
+}
+
+/** Patch for an event — any subset of the editable fields. */
+model UpdateEvent {
+  title?: string;
+  start?: string | null;
+  end?: string | null;
+  allDay?: boolean;
+  description?: string | null;
+  location?: string | null;
+  keywords?: string[];
+}
+
+/** Fields to create an owned task in a calendar. */
+model CreateTask {
+  title: string;
+  space?: string;
+  path?: string;
+  status?: "todo" | "in_progress" | "blocked" | "done";
+  /** JSCalendar percentComplete (0..100). */
+  progress?: int32;
+  start?: string;
+  due?: string;
+  priority?: "low" | "normal" | "high";
+  keywords?: string[];
+}
+
+/** Patch for an owned task — any subset of the editable fields. */
+model UpdateTask {
+  title?: string;
+  status?: "todo" | "in_progress" | "blocked" | "done";
+  progress?: int32;
+  start?: string | null;
+  due?: string | null;
+  priority?: "low" | "normal" | "high";
+  keywords?: string[];
+}
+
+/** The caller's owned calendars. */
+model CalendarsList {
+  calendars: Calendar[];
+}
+
+/** Share a calendar (folder) with a person by email. */
+model ShareCalendar {
+  space: string;
+  path: string;
+  email: string;
+  role?: "viewer" | "editor";
 }
 
 // ───────────────────────────── misc ──────────────────────────────────────────

--- a/apps/api/spec/openapi.yaml
+++ b/apps/api/spec/openapi.yaml
@@ -138,7 +138,10 @@ paths:
   /api/calendar:
     get:
       operationId: listCalendar
-      description: Calendar events from the caller's configured source. `?from=`/`?to=` are ISO 8601.
+      description: |-
+        The aggregated calendar stream: owned events from the scheduling store plus
+        any data-source provider's (GitHub), with the caller's owned calendars for the
+        aggregator's calendar list. `?from=`/`?to=` are ISO 8601; `?space=` scopes.
       parameters:
         - name: from
           in: query
@@ -147,6 +150,12 @@ paths:
             type: string
           explode: false
         - name: to
+          in: query
+          required: false
+          schema:
+            type: string
+          explode: false
+        - name: space
           in: query
           required: false
           schema:
@@ -167,6 +176,77 @@ paths:
                 $ref: '#/components/schemas/Error'
       security:
         - {}
+  /api/calendars:
+    get:
+      operationId: listCalendars
+      description: The caller's owned calendars (= virtual folders). `?space=` scopes to one space.
+      parameters:
+        - name: space
+          in: query
+          required: false
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarsList'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      operationId: createCalendar
+      description: Create a calendar (a colored virtual folder) in a space.
+      parameters: []
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Calendar'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCalendar'
+  /api/calendars/share:
+    post:
+      operationId: shareCalendar
+      description: Share a calendar (folder) with a person by email.
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Ok'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ShareCalendar'
   /api/changes:
     get:
       operationId: changesSince
@@ -509,6 +589,86 @@ paths:
                     type: boolean
                 required:
                   - started
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /api/events:
+    post:
+      operationId: createEvent
+      description: Create an event in a calendar.
+      parameters: []
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateEvent'
+  /api/events/{id}:
+    patch:
+      operationId: updateEvent
+      description: Patch an event.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  updated:
+                    $ref: '#/components/schemas/Event'
+                required:
+                  - updated
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateEvent'
+    delete:
+      operationId: deleteEvent
+      description: Soft-delete an event.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Ok'
         default:
           description: An unexpected error response.
           content:
@@ -2318,8 +2478,16 @@ paths:
   /api/tasks:
     get:
       operationId: listTasks
-      description: Tasks from the caller's configured source (or the demo default).
-      parameters: []
+      description: |-
+        Tasks the caller can see: owned tasks from the scheduling store plus any
+        data-source provider's (GitHub). `?space=` scopes to one space.
+      parameters:
+        - name: space
+          in: query
+          required: false
+          schema:
+            type: string
+          explode: false
       responses:
         '200':
           description: The request has succeeded.
@@ -2335,6 +2503,85 @@ paths:
                 $ref: '#/components/schemas/Error'
       security:
         - {}
+    post:
+      operationId: createTask
+      description: Create an owned task in a calendar.
+      parameters: []
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTask'
+  /api/tasks/{id}:
+    patch:
+      operationId: updateTask
+      description: Patch an owned task.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  updated:
+                    $ref: '#/components/schemas/Task'
+                required:
+                  - updated
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTask'
+    delete:
+      operationId: deleteTask
+      description: Soft-delete an owned task.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Ok'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/uploads/prepare:
     post:
       operationId: prepareUpload
@@ -2651,6 +2898,38 @@ components:
           items:
             $ref: '#/components/schemas/BranchInfo'
       description: "The connected space's branches, or `supported: false` for a NAS with no branch concept."
+    Calendar:
+      type: object
+      required:
+        - id
+        - spaceId
+        - path
+        - name
+        - role
+      properties:
+        id:
+          type: string
+          description: Stable id = `${spaceId}${path}` (the folder object id).
+        spaceId:
+          type: string
+          x-references: Space
+        path:
+          type: string
+          description: Virtual-folder path within the space ("" = the implicit root calendar).
+        name:
+          type: string
+        color:
+          type: string
+          nullable: true
+          description: Accent color — an HSL triplet like "212 92% 50%", or null to inherit the space color.
+        role:
+          allOf:
+            - $ref: '#/components/schemas/Role'
+          description: The caller's effective role on this calendar (folder grant ∪ space membership).
+        createdAt:
+          type: string
+          format: date-time
+      description: 'A calendar: a shareable virtual folder of scheduling items.'
     CalendarEvent:
       type: object
       required:
@@ -2682,7 +2961,26 @@ components:
         tone:
           type: string
           description: Accent token.
-      description: A calendar event surfaced by a data-source plugin.
+        spaceId:
+          type: string
+          description: 'Owned events: the space the event lives in.'
+        path:
+          type: string
+          description: 'Owned events: the calendar (folder) path within the space ("" = root).'
+        calendarId:
+          type: string
+          description: 'Owned events: the calendar id = `${spaceId}${path}`.'
+        color:
+          type: string
+          description: "Owned events: the calendar's accent color (HSL triplet)."
+        editable:
+          type: boolean
+          description: 'Owned events: whether the caller may edit it.'
+      description: |-
+        A calendar event in the flat view shape the Calendar plugin renders. Either
+        surfaced by a data-source plugin (GitHub milestones/releases) or an owned event
+        projected from the scheduling store (#34) — owned events carry their calendar
+        coordinates so the aggregator can group, color, and toggle by calendar.
     CalendarList:
       type: object
       required:
@@ -2691,11 +2989,27 @@ components:
         source:
           type: string
           nullable: true
+          description: Which sources contributed (e.g. "owned", "github", "owned+github").
         events:
           type: array
           items:
             $ref: '#/components/schemas/CalendarEvent'
-      description: Events from the active source.
+        calendars:
+          type: array
+          items:
+            $ref: '#/components/schemas/Calendar'
+          description: The caller's owned calendars (= virtual folders), for the aggregator's calendar list.
+      description: Events from the active source(s), plus the caller's owned calendars.
+    CalendarsList:
+      type: object
+      required:
+        - calendars
+      properties:
+        calendars:
+          type: array
+          items:
+            $ref: '#/components/schemas/Calendar'
+      description: The caller's owned calendars.
     CapAiGenerate:
       type: object
       required:
@@ -2989,6 +3303,23 @@ components:
         from:
           type: string
       description: Create a branch on the backend (from another ref, default = the current branch).
+    CreateCalendar:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        space:
+          type: string
+          description: Target space; omit for the caller's personal space.
+        path:
+          type: string
+          description: Folder path; defaults to a slug of `name`.
+        color:
+          type: string
+          nullable: true
+      description: Fields to create a calendar (a colored virtual folder) in a space.
     CreateComment:
       type: object
       required:
@@ -3008,6 +3339,34 @@ components:
         source:
           type: string
       description: Submit a Studio-generated plugin (manifest + source).
+    CreateEvent:
+      type: object
+      required:
+        - title
+      properties:
+        title:
+          type: string
+        space:
+          type: string
+          description: Target space; omit for the caller's personal space.
+        path:
+          type: string
+          description: Calendar folder path ("" = the space's root calendar).
+        start:
+          type: string
+        end:
+          type: string
+        allDay:
+          type: boolean
+        description:
+          type: string
+        location:
+          type: string
+        keywords:
+          type: array
+          items:
+            type: string
+      description: Fields to create an event in a calendar.
     CreateFile:
       type: object
       required:
@@ -3084,6 +3443,43 @@ components:
           type: string
           nullable: true
       description: Fields accepted when creating a shared (group) space.
+    CreateTask:
+      type: object
+      required:
+        - title
+      properties:
+        title:
+          type: string
+        space:
+          type: string
+        path:
+          type: string
+        status:
+          type: string
+          enum:
+            - todo
+            - in_progress
+            - blocked
+            - done
+        progress:
+          type: integer
+          format: int32
+          description: JSCalendar percentComplete (0..100).
+        start:
+          type: string
+        due:
+          type: string
+        priority:
+          type: string
+          enum:
+            - low
+            - normal
+            - high
+        keywords:
+          type: array
+          items:
+            type: string
+      description: Fields to create an owned task in a calendar.
     CustomPlugin:
       type: object
       required:
@@ -3175,6 +3571,64 @@ components:
           description: HTTP-aligned error code.
         message:
           type: string
+    Event:
+      type: object
+      required:
+        - id
+        - spaceId
+        - path
+        - uid
+        - title
+        - allDay
+        - keywords
+        - etag
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+        spaceId:
+          type: string
+          x-references: Space
+        path:
+          type: string
+          description: The calendar (folder) path within the space.
+        uid:
+          type: string
+          description: JSCalendar logical identity (iCal UID).
+        title:
+          type: string
+        start:
+          type: string
+          nullable: true
+          description: ISO 8601 (date or date-time).
+        end:
+          type: string
+          nullable: true
+          description: ISO 8601; omit for point-in-time / all-day.
+        allDay:
+          type: boolean
+        description:
+          type: string
+          nullable: true
+        location:
+          type: string
+          nullable: true
+        keywords:
+          type: array
+          items:
+            type: string
+          description: Tags (JSCalendar keywords) — classification only, no permission meaning.
+        etag:
+          type: string
+          description: Content hash of the JSCalendar object.
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      description: An owned calendar event (JSCalendar-shaped record).
     File:
       type: object
       required:
@@ -3740,6 +4194,35 @@ components:
           type: integer
           format: int64
       description: Request to reserve an upload slot for content with the given hash.
+    Principal:
+      type: object
+      required:
+        - id
+        - kind
+      properties:
+        id:
+          type: string
+        spaceId:
+          type: string
+          nullable: true
+          x-references: Space
+        kind:
+          type: string
+          enum:
+            - person
+        sub:
+          type: string
+          allOf:
+            - $ref: '#/components/schemas/Sub'
+          nullable: true
+          description: Links to a Canopy user when known.
+        email:
+          type: string
+          nullable: true
+        name:
+          type: string
+          nullable: true
+      description: A person principal — an identity hub events reference as a participant.
     ProcessingRun:
       type: object
       required:
@@ -3881,6 +4364,25 @@ components:
           format: int32
           nullable: true
       description: Update a connected space's version-retention policy.
+    ShareCalendar:
+      type: object
+      required:
+        - space
+        - path
+        - email
+      properties:
+        space:
+          type: string
+        path:
+          type: string
+        email:
+          type: string
+        role:
+          type: string
+          enum:
+            - viewer
+            - editor
+      description: Share a calendar (folder) with a person by email.
     ShareInfo:
       type: object
       required:
@@ -4088,8 +4590,11 @@ components:
         - pending
       properties:
         sub:
-          allOf:
+          anyOf:
             - $ref: '#/components/schemas/Sub'
+            - type: string
+              enum:
+                - ''
           description: The user's sub, or "" for a pending email invite.
         role:
           $ref: '#/components/schemas/Role'
@@ -4191,7 +4696,22 @@ components:
             - high
         url:
           type: string
-      description: A task surfaced by a data-source plugin.
+        spaceId:
+          type: string
+          description: 'Owned tasks: the space the task lives in.'
+        path:
+          type: string
+          description: 'Owned tasks: the calendar (folder) path within the space.'
+        calendarId:
+          type: string
+          description: 'Owned tasks: the calendar id = `${spaceId}${path}`.'
+        editable:
+          type: boolean
+          description: 'Owned tasks: whether the caller may edit it.'
+      description: |-
+        A task in the flat view shape the Tasks plugin renders. Either surfaced by a
+        data-source plugin (GitHub issues) or an owned task projected from the
+        scheduling store (#34) — owned tasks carry their calendar coordinates.
     TaskList:
       type: object
       required:
@@ -4200,11 +4720,68 @@ components:
         source:
           type: string
           nullable: true
+          description: Which sources contributed (e.g. "owned", "github", "owned+github").
         tasks:
           type: array
           items:
             $ref: '#/components/schemas/Task'
-      description: Tasks from the active source.
+      description: Tasks from the active source(s).
+    UpdateEvent:
+      type: object
+      properties:
+        title:
+          type: string
+        start:
+          type: string
+          nullable: true
+        end:
+          type: string
+          nullable: true
+        allDay:
+          type: boolean
+        description:
+          type: string
+          nullable: true
+        location:
+          type: string
+          nullable: true
+        keywords:
+          type: array
+          items:
+            type: string
+      description: Patch for an event — any subset of the editable fields.
+    UpdateTask:
+      type: object
+      properties:
+        title:
+          type: string
+        status:
+          type: string
+          enum:
+            - todo
+            - in_progress
+            - blocked
+            - done
+        progress:
+          type: integer
+          format: int32
+        start:
+          type: string
+          nullable: true
+        due:
+          type: string
+          nullable: true
+        priority:
+          type: string
+          enum:
+            - low
+            - normal
+            - high
+        keywords:
+          type: array
+          items:
+            type: string
+      description: Patch for an owned task — any subset of the editable fields.
     UploadTicket:
       type: object
       required:

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,6 +7,8 @@ import {
   type AiMessage,
   type AiModel,
   type AiProvider,
+  type Calendar,
+  type CalendarEvent,
   type Capability,
   type CacheStore,
   type ConnectorConfigField,
@@ -14,6 +16,7 @@ import {
   type SearchIndex,
   type ServerDataSource,
   type StorageConnector,
+  type Task,
 } from "@canopy/core";
 import {
   BlobHashMismatchError,
@@ -24,8 +27,11 @@ import {
   crawlConnector,
   type BlobStore,
   type Caller,
+  type EventInput,
   type FileService,
   type IndexJobs,
+  type SchedulingStore,
+  type TaskInput,
   type VersionPolicyKind,
 } from "@canopy/store";
 import type { DocWorker } from "@canopy/docworker";
@@ -185,6 +191,13 @@ export interface AppDeps {
   readonlyMounts?: Record<string, StorageConnector>;
   /** The user's drive, backed by @canopy/store (D1/libsql + R2/fs). */
   drive?: DriveDeps;
+  /**
+   * The owned scheduling store (#34): calendars (= virtual folders), events, and
+   * tasks the user creates, reusing the drive's space/folder/permission model.
+   * Reads aggregate into `/api/calendar` and `/api/tasks` alongside external
+   * data-source providers; writes go through the dedicated REST routes here.
+   */
+  scheduling?: SchedulingStore;
   /** Connected data-source plugins feeding tasks/calendar. */
   dataSources?: DataSourceDeps;
   /** Server-side document processors run when a file is added (e.g. AI labeling). */
@@ -239,7 +252,7 @@ const ANON_DEFAULT_PLUGINS = ["documentation", ...DEFAULT_PLUGINS];
  */
 export function createApp(deps: AppDeps) {
   const app = new Hono();
-  const { authConfig = null, readonlyMounts = {}, drive, dataSources, processors = [], ai } = deps;
+  const { authConfig = null, readonlyMounts = {}, drive, scheduling, dataSources, processors = [], ai } = deps;
   // Run background work via the host's keep-alive (Worker ctx.waitUntil) if given;
   // on Node a bare promise survives because the process stays up.
   const runBackground = (p: Promise<unknown>) => (deps.waitUntil ? deps.waitUntil(p) : void p);
@@ -1362,25 +1375,201 @@ export function createApp(deps: AppDeps) {
     }),
   );
 
+  // ── scheduling: calendars, events, tasks (owned + aggregated) ───────────────
+  // Reads aggregate the owned scheduling store (#34) with external data-source
+  // providers (GitHub etc.) into one stream the calendar/tasks plugins render.
+  // Owned items carry their calendar coordinates (spaceId/path/calendarId/color)
+  // so the aggregator can group, color, and toggle by calendar; provider items
+  // don't (they aren't space-scoped). Writes go through the dedicated routes below
+  // and reuse the drive's folder-grant ACL via the scheduling store.
+
+  /** Owned calendars the caller can see (= virtual folders), optionally one space. */
+  app.get("/api/calendars", (c) =>
+    handle(c, async () => {
+      const caller = await callerOf(c);
+      if (!caller || !scheduling) return c.json({ calendars: [] });
+      return c.json({ calendars: await scheduling.listCalendars(caller, c.req.query("space") ?? undefined) });
+    }),
+  );
+
+  /** Create a calendar in a space (a colored virtual folder). */
+  app.post("/api/calendars", (c) =>
+    handle(c, async () => {
+      const caller = await callerOf(c);
+      if (!caller) return c.json({ error: "unauthorized" }, 401);
+      if (!scheduling || !drive) return c.json({ error: "scheduling unavailable" }, 503);
+      const body = (await c.req.json()) as { name: string; path?: string; color?: string | null; space?: string };
+      const spaceId = body.space ?? (await drive.service.personalSpace(caller.sub));
+      const created = await scheduling.createCalendar(caller, { spaceId, name: body.name, path: body.path, color: body.color });
+      return c.json({ created }, 201);
+    }),
+  );
+
+  /** Share a calendar (folder) with a person by email. */
+  app.post("/api/calendars/share", (c) =>
+    handle(c, async () => {
+      const caller = await callerOf(c);
+      if (!caller) return c.json({ error: "unauthorized" }, 401);
+      if (!scheduling) return c.json({ error: "scheduling unavailable" }, 503);
+      const body = (await c.req.json()) as { space: string; path: string; email: string; role?: "viewer" | "editor" };
+      await scheduling.shareCalendar(caller, body.space, body.path, body.email, body.role ?? "viewer");
+      return c.json({ ok: true });
+    }),
+  );
+
   app.get("/api/tasks", (c) =>
     handle(c, async () => {
+      const caller = await callerOf(c);
+      // Owned tasks first (when signed in), then the GitHub provider's, so both
+      // surface in the Tasks plugin. `source` reflects what contributed.
+      const owned = caller && scheduling ? await scheduling.listTasks(caller, { spaceId: c.req.query("space") ?? undefined }) : [];
+      const ownedTasks: Task[] = owned.map((t) => ({
+        id: t.id,
+        title: t.title,
+        status: t.status,
+        due: t.due ?? undefined,
+        labels: t.keywords,
+        spaceId: t.spaceId,
+        path: t.path,
+        calendarId: `${t.spaceId}${t.path}`,
+        editable: true,
+      }));
       const resolved = await resolveConfig(c, "github");
       const provider = resolved ? providersFor("github", resolved).tasks : undefined;
-      if (!provider) return c.json({ source: null, tasks: [] });
-      return c.json({ source: "github", tasks: await provider.listTasks() });
+      const ghTasks = provider ? await provider.listTasks() : [];
+      const source = ownedTasks.length ? (ghTasks.length ? "owned+github" : "owned") : ghTasks.length ? "github" : null;
+      return c.json({ source, tasks: [...ownedTasks, ...ghTasks] });
     }),
   );
 
   app.get("/api/calendar", (c) =>
     handle(c, async () => {
-      const resolved = await resolveConfig(c, "github");
-      const provider = resolved ? providersFor("github", resolved).calendar : undefined;
-      if (!provider) return c.json({ source: null, events: [] });
       // Default window: 30 days back through 90 days ahead (covers releases + milestones).
       const now = Date.now();
       const from = c.req.query("from") ?? new Date(now - 30 * 864e5).toISOString();
       const to = c.req.query("to") ?? new Date(now + 90 * 864e5).toISOString();
-      return c.json({ source: "github", events: await provider.listEvents({ from, to }) });
+      const caller = await callerOf(c);
+      const space = c.req.query("space") ?? undefined;
+
+      // Owned events, projected to the flat view shape with calendar coordinates.
+      let ownedEvents: CalendarEvent[] = [];
+      let calendars: Calendar[] = [];
+      if (caller && scheduling) {
+        calendars = await scheduling.listCalendars(caller, space);
+        const colorOf = new Map(calendars.map((cal) => [`${cal.spaceId}${cal.path}`, cal.color ?? undefined]));
+        const editableOf = new Map(calendars.map((cal) => [`${cal.spaceId}${cal.path}`, cal.role !== "viewer"]));
+        const events = await scheduling.listEvents(caller, { range: { from, to }, spaceId: space });
+        ownedEvents = events.map((e) => {
+          const calendarId = `${e.spaceId}${e.path}`;
+          return {
+            id: e.id,
+            title: e.title,
+            start: e.start ?? "",
+            end: e.end ?? undefined,
+            allDay: e.allDay,
+            kind: "event",
+            spaceId: e.spaceId,
+            path: e.path,
+            calendarId,
+            color: colorOf.get(calendarId),
+            editable: editableOf.get(calendarId) ?? true,
+          } satisfies CalendarEvent;
+        });
+      }
+
+      const resolved = await resolveConfig(c, "github");
+      const provider = resolved ? providersFor("github", resolved).calendar : undefined;
+      const ghEvents = provider ? await provider.listEvents({ from, to }) : [];
+      const source = ownedEvents.length ? (ghEvents.length ? "owned+github" : "owned") : ghEvents.length ? "github" : null;
+      return c.json({ source, events: [...ownedEvents, ...ghEvents], calendars });
+    }),
+  );
+
+  /** Create an event in a calendar. */
+  app.post("/api/events", (c) =>
+    handle(c, async () => {
+      const caller = await callerOf(c);
+      if (!caller) return c.json({ error: "unauthorized" }, 401);
+      if (!scheduling || !drive) return c.json({ error: "scheduling unavailable" }, 503);
+      const body = (await c.req.json()) as Partial<EventInput> & { space?: string };
+      const spaceId = body.spaceId ?? body.space ?? (await drive.service.personalSpace(caller.sub));
+      if (!body.title) return c.json({ error: "title required" }, 400);
+      const created = await scheduling.createEvent(caller, {
+        spaceId,
+        path: body.path,
+        title: body.title,
+        start: body.start,
+        end: body.end,
+        allDay: body.allDay,
+        description: body.description,
+        location: body.location,
+        keywords: body.keywords,
+      });
+      return c.json({ created }, 201);
+    }),
+  );
+
+  app.patch("/api/events/:id", (c) =>
+    handle(c, async () => {
+      const caller = await callerOf(c);
+      if (!caller) return c.json({ error: "unauthorized" }, 401);
+      if (!scheduling) return c.json({ error: "scheduling unavailable" }, 503);
+      const body = (await c.req.json()) as Partial<EventInput>;
+      return c.json({ updated: await scheduling.updateEvent(caller, c.req.param("id"), body) });
+    }),
+  );
+
+  app.delete("/api/events/:id", (c) =>
+    handle(c, async () => {
+      const caller = await callerOf(c);
+      if (!caller) return c.json({ error: "unauthorized" }, 401);
+      if (!scheduling) return c.json({ error: "scheduling unavailable" }, 503);
+      await scheduling.deleteEvent(caller, c.req.param("id"));
+      return c.json({ ok: true });
+    }),
+  );
+
+  /** Create a task in a calendar. */
+  app.post("/api/tasks", (c) =>
+    handle(c, async () => {
+      const caller = await callerOf(c);
+      if (!caller) return c.json({ error: "unauthorized" }, 401);
+      if (!scheduling || !drive) return c.json({ error: "scheduling unavailable" }, 503);
+      const body = (await c.req.json()) as Partial<TaskInput> & { space?: string };
+      const spaceId = body.spaceId ?? body.space ?? (await drive.service.personalSpace(caller.sub));
+      if (!body.title) return c.json({ error: "title required" }, 400);
+      const created = await scheduling.createTask(caller, {
+        spaceId,
+        path: body.path,
+        title: body.title,
+        status: body.status,
+        progress: body.progress,
+        start: body.start,
+        due: body.due,
+        priority: body.priority,
+        keywords: body.keywords,
+      });
+      return c.json({ created }, 201);
+    }),
+  );
+
+  app.patch("/api/tasks/:id", (c) =>
+    handle(c, async () => {
+      const caller = await callerOf(c);
+      if (!caller) return c.json({ error: "unauthorized" }, 401);
+      if (!scheduling) return c.json({ error: "scheduling unavailable" }, 503);
+      const body = (await c.req.json()) as Partial<TaskInput>;
+      return c.json({ updated: await scheduling.updateTask(caller, c.req.param("id"), body) });
+    }),
+  );
+
+  app.delete("/api/tasks/:id", (c) =>
+    handle(c, async () => {
+      const caller = await callerOf(c);
+      if (!caller) return c.json({ error: "unauthorized" }, 401);
+      if (!scheduling) return c.json({ error: "scheduling unavailable" }, 503);
+      await scheduling.deleteTask(caller, c.req.param("id"));
+      return c.json({ ok: true });
     }),
   );
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -86,6 +86,15 @@ const SANDBOX_VIEWER_CAPS = new Set(["item:read", "item:write", "net:fetch"]);
  * (The browser validates against the full JSON schema before submitting; this is
  * the server's defense-in-depth copy.)
  */
+/** Reject task status/priority values outside their enums before they reach the store. */
+function invalidTaskField(body: Partial<TaskInput>): string | null {
+  if (body.status !== undefined && !["todo", "in_progress", "blocked", "done"].includes(body.status))
+    return `invalid status: ${body.status}`;
+  if (body.priority != null && !["low", "normal", "high"].includes(body.priority))
+    return `invalid priority: ${body.priority}`;
+  return null;
+}
+
 function validateCustomManifest(m: unknown): string | null {
   if (!m || typeof m !== "object") return "manifest must be an object";
   const man = m as { id?: unknown; name?: unknown; capabilities?: unknown; contributes?: unknown };
@@ -1399,9 +1408,10 @@ export function createApp(deps: AppDeps) {
       if (!caller) return c.json({ error: "unauthorized" }, 401);
       if (!scheduling || !drive) return c.json({ error: "scheduling unavailable" }, 503);
       const body = (await c.req.json()) as { name: string; path?: string; color?: string | null; space?: string };
+      if (!body.name?.trim()) return c.json({ error: "name required" }, 400);
       const spaceId = body.space ?? (await drive.service.personalSpace(caller.sub));
       const created = await scheduling.createCalendar(caller, { spaceId, name: body.name, path: body.path, color: body.color });
-      return c.json({ created }, 201);
+      return c.json(created, 201);
     }),
   );
 
@@ -1432,11 +1442,12 @@ export function createApp(deps: AppDeps) {
         spaceId: t.spaceId,
         path: t.path,
         calendarId: `${t.spaceId}${t.path}`,
-        editable: true,
+        editable: t.role !== "viewer",
       }));
+      // A failing external provider must not sink the caller's own tasks.
       const resolved = await resolveConfig(c, "github");
       const provider = resolved ? providersFor("github", resolved).tasks : undefined;
-      const ghTasks = provider ? await provider.listTasks() : [];
+      const ghTasks = provider ? await provider.listTasks().catch(() => []) : [];
       const source = ownedTasks.length ? (ghTasks.length ? "owned+github" : "owned") : ghTasks.length ? "github" : null;
       return c.json({ source, tasks: [...ownedTasks, ...ghTasks] });
     }),
@@ -1457,29 +1468,33 @@ export function createApp(deps: AppDeps) {
       if (caller && scheduling) {
         calendars = await scheduling.listCalendars(caller, space);
         const colorOf = new Map(calendars.map((cal) => [`${cal.spaceId}${cal.path}`, cal.color ?? undefined]));
-        const editableOf = new Map(calendars.map((cal) => [`${cal.spaceId}${cal.path}`, cal.role !== "viewer"]));
         const events = await scheduling.listEvents(caller, { range: { from, to }, spaceId: space });
-        ownedEvents = events.map((e) => {
-          const calendarId = `${e.spaceId}${e.path}`;
-          return {
-            id: e.id,
-            title: e.title,
-            start: e.start ?? "",
-            end: e.end ?? undefined,
-            allDay: e.allDay,
-            kind: "event",
-            spaceId: e.spaceId,
-            path: e.path,
-            calendarId,
-            color: colorOf.get(calendarId),
-            editable: editableOf.get(calendarId) ?? true,
-          } satisfies CalendarEvent;
-        });
+        // A calendar view can't place a start-less (unscheduled) event, and
+        // CalendarEvent.start must be non-empty, so drop those here.
+        ownedEvents = events
+          .filter((e) => e.start)
+          .map((e) => {
+            const calendarId = `${e.spaceId}${e.path}`;
+            return {
+              id: e.id,
+              title: e.title,
+              start: e.start as string,
+              end: e.end ?? undefined,
+              allDay: e.allDay,
+              kind: "event",
+              spaceId: e.spaceId,
+              path: e.path,
+              calendarId,
+              color: colorOf.get(calendarId),
+              editable: e.role !== "viewer",
+            } satisfies CalendarEvent;
+          });
       }
 
+      // A failing external provider must not sink the caller's own events.
       const resolved = await resolveConfig(c, "github");
       const provider = resolved ? providersFor("github", resolved).calendar : undefined;
-      const ghEvents = provider ? await provider.listEvents({ from, to }) : [];
+      const ghEvents = provider ? await provider.listEvents({ from, to }).catch(() => []) : [];
       const source = ownedEvents.length ? (ghEvents.length ? "owned+github" : "owned") : ghEvents.length ? "github" : null;
       return c.json({ source, events: [...ownedEvents, ...ghEvents], calendars });
     }),
@@ -1505,7 +1520,7 @@ export function createApp(deps: AppDeps) {
         location: body.location,
         keywords: body.keywords,
       });
-      return c.json({ created }, 201);
+      return c.json(created, 201);
     }),
   );
 
@@ -1538,6 +1553,8 @@ export function createApp(deps: AppDeps) {
       const body = (await c.req.json()) as Partial<TaskInput> & { space?: string };
       const spaceId = body.spaceId ?? body.space ?? (await drive.service.personalSpace(caller.sub));
       if (!body.title) return c.json({ error: "title required" }, 400);
+      const invalid = invalidTaskField(body);
+      if (invalid) return c.json({ error: invalid }, 400);
       const created = await scheduling.createTask(caller, {
         spaceId,
         path: body.path,
@@ -1549,7 +1566,7 @@ export function createApp(deps: AppDeps) {
         priority: body.priority,
         keywords: body.keywords,
       });
-      return c.json({ created }, 201);
+      return c.json(created, 201);
     }),
   );
 
@@ -1559,6 +1576,8 @@ export function createApp(deps: AppDeps) {
       if (!caller) return c.json({ error: "unauthorized" }, 401);
       if (!scheduling) return c.json({ error: "scheduling unavailable" }, 503);
       const body = (await c.req.json()) as Partial<TaskInput>;
+      const invalid = invalidTaskField(body);
+      if (invalid) return c.json({ error: invalid }, 400);
       return c.json({ updated: await scheduling.updateTask(caller, c.req.param("id"), body) });
     }),
   );

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -18,6 +18,7 @@ import {
   inProcessIndexJobs,
   resolveInvites,
   runMigrations,
+  SchedulingStore,
   syncAllConnectors,
   upsertUser,
   type FileRecord,
@@ -179,6 +180,7 @@ const app = createApp({
   authConfig,
   readonlyMounts: { documentation, demo },
   drive: { service, blobs, docWorker: inProcessDocWorker() },
+  scheduling: new SchedulingStore(db),
   dataSources,
   // In-process connector indexing (full crawl + extract drain) for the "Sync now" /
   // on-connect triggers; the periodic sweep below stays the safety net.

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -14,6 +14,7 @@ import {
   inProcessIndexJobs,
   resolveInvites,
   runMigrations,
+  SchedulingStore,
   syncAllConnectors,
   upsertUser,
   type CrawlTarget,
@@ -280,6 +281,7 @@ export default {
         blobs,
         docWorker: env.DOCWORKER ? containerDocWorker(env.DOCWORKER, env.DOCWORKER_TOKEN) : inProcessDocWorker(),
       },
+      scheduling: new SchedulingStore(db),
       dataSources,
       // D1 FTS5 search index — the same SQL adapter as libsql on Node.
       search,

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -1844,9 +1844,9 @@ export async function createCalendar(input: {
     headers: { "content-type": "application/json" },
     body: JSON.stringify(input),
   });
-  const data = (await res.json().catch(() => ({}))) as { created?: Calendar; error?: string };
-  if (!res.ok || !data.created) throw new Error(data.error ?? `create calendar failed: ${res.status}`);
-  return data.created;
+  const data = (await res.json().catch(() => ({}))) as Calendar & { error?: string };
+  if (!res.ok || !data.id) throw new Error(data.error ?? `create calendar failed: ${res.status}`);
+  return data;
 }
 
 /** Share a calendar (folder) with a person by email. */
@@ -1883,9 +1883,9 @@ export async function createEvent(input: CreateEventInput): Promise<{ id: string
     headers: { "content-type": "application/json" },
     body: JSON.stringify(input),
   });
-  const data = (await res.json().catch(() => ({}))) as { created?: { id: string }; error?: string };
-  if (!res.ok || !data.created) throw new Error(data.error ?? `create event failed: ${res.status}`);
-  return data.created;
+  const data = (await res.json().catch(() => ({}))) as { id?: string; error?: string };
+  if (!res.ok || !data.id) throw new Error(data.error ?? `create event failed: ${res.status}`);
+  return { id: data.id };
 }
 
 export async function updateEvent(id: string, patch: Partial<CreateEventInput>): Promise<void> {
@@ -1921,9 +1921,9 @@ export async function createTask(input: CreateTaskInput): Promise<{ id: string }
     headers: { "content-type": "application/json" },
     body: JSON.stringify(input),
   });
-  const data = (await res.json().catch(() => ({}))) as { created?: { id: string }; error?: string };
-  if (!res.ok || !data.created) throw new Error(data.error ?? `create task failed: ${res.status}`);
-  return data.created;
+  const data = (await res.json().catch(() => ({}))) as { id?: string; error?: string };
+  if (!res.ok || !data.id) throw new Error(data.error ?? `create task failed: ${res.status}`);
+  return { id: data.id };
 }
 
 export async function updateTask(id: string, patch: Partial<CreateTaskInput>): Promise<void> {

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -1610,6 +1610,11 @@ export interface Task {
   labels?: string[];
   priority?: "low" | "normal" | "high";
   url?: string;
+  /** Owned tasks (#34): the calendar (folder) the task lives in. */
+  spaceId?: string;
+  path?: string;
+  calendarId?: string;
+  editable?: boolean;
 }
 
 export interface CalendarEvent {
@@ -1621,6 +1626,22 @@ export interface CalendarEvent {
   kind?: "milestone" | "release" | "issue" | "event";
   url?: string;
   tone?: string;
+  /** Owned events (#34): calendar coordinates so the aggregator can group/color/toggle. */
+  spaceId?: string;
+  path?: string;
+  calendarId?: string;
+  color?: string;
+  editable?: boolean;
+}
+
+/** A calendar: a shareable virtual folder of scheduling items (#34). */
+export interface Calendar {
+  id: string;
+  spaceId: string;
+  path: string;
+  name: string;
+  color?: string | null;
+  role: "viewer" | "editor" | "owner";
 }
 
 /** What external sources are connected (e.g. GitHub), so views show live vs. sample. */
@@ -1784,15 +1805,139 @@ export async function getTasks(): Promise<{ source: string | null; tasks: Task[]
   return (await res.json()) as { source: string | null; tasks: Task[] };
 }
 
-/** Calendar events from the connected source. `source` is null when none. */
+/**
+ * The aggregated calendar stream: the caller's owned events plus any connected
+ * source's, with the caller's owned calendars for the aggregator's calendar list.
+ * `source` is null when nothing contributed.
+ */
 export async function getCalendar(range?: { from: string; to: string }): Promise<{
   source: string | null;
   events: CalendarEvent[];
+  calendars: Calendar[];
 }> {
   const q = range ? `?from=${encodeURIComponent(range.from)}&to=${encodeURIComponent(range.to)}` : "";
   const res = await apiFetch(`/api/calendar${q}`);
-  if (!res.ok) return { source: null, events: [] };
-  return (await res.json()) as { source: string | null; events: CalendarEvent[] };
+  if (!res.ok) return { source: null, events: [], calendars: [] };
+  const data = (await res.json()) as { source: string | null; events: CalendarEvent[]; calendars?: Calendar[] };
+  return { source: data.source, events: data.events, calendars: data.calendars ?? [] };
+}
+
+// ── owned scheduling: calendars / events / tasks (#34) ────────────────────────
+
+/** The caller's owned calendars (= virtual folders). `space` scopes to one space. */
+export async function listCalendars(space?: string): Promise<Calendar[]> {
+  const q = space ? `?space=${encodeURIComponent(space)}` : "";
+  const res = await apiFetch(`/api/calendars${q}`);
+  if (!res.ok) return [];
+  return ((await res.json()) as { calendars?: Calendar[] }).calendars ?? [];
+}
+
+/** Create a calendar (a colored virtual folder) in a space. */
+export async function createCalendar(input: {
+  name: string;
+  space?: string;
+  path?: string;
+  color?: string | null;
+}): Promise<Calendar> {
+  const res = await apiFetch("/api/calendars", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const data = (await res.json().catch(() => ({}))) as { created?: Calendar; error?: string };
+  if (!res.ok || !data.created) throw new Error(data.error ?? `create calendar failed: ${res.status}`);
+  return data.created;
+}
+
+/** Share a calendar (folder) with a person by email. */
+export async function shareCalendar(input: {
+  space: string;
+  path: string;
+  email: string;
+  role?: "viewer" | "editor";
+}): Promise<void> {
+  const res = await apiFetch("/api/calendars/share", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) throw new Error(`share calendar failed: ${res.status}`);
+}
+
+export interface CreateEventInput {
+  title: string;
+  space?: string;
+  path?: string;
+  start?: string;
+  end?: string;
+  allDay?: boolean;
+  description?: string;
+  location?: string;
+  keywords?: string[];
+}
+
+/** Create an owned event in a calendar. Returns the stored event id. */
+export async function createEvent(input: CreateEventInput): Promise<{ id: string }> {
+  const res = await apiFetch("/api/events", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const data = (await res.json().catch(() => ({}))) as { created?: { id: string }; error?: string };
+  if (!res.ok || !data.created) throw new Error(data.error ?? `create event failed: ${res.status}`);
+  return data.created;
+}
+
+export async function updateEvent(id: string, patch: Partial<CreateEventInput>): Promise<void> {
+  const res = await apiFetch(`/api/events/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) throw new Error(`update event failed: ${res.status}`);
+}
+
+export async function deleteEvent(id: string): Promise<void> {
+  const res = await apiFetch(`/api/events/${encodeURIComponent(id)}`, { method: "DELETE" });
+  if (!res.ok) throw new Error(`delete event failed: ${res.status}`);
+}
+
+export interface CreateTaskInput {
+  title: string;
+  space?: string;
+  path?: string;
+  status?: TaskStatus;
+  progress?: number;
+  start?: string;
+  due?: string;
+  priority?: "low" | "normal" | "high";
+  keywords?: string[];
+}
+
+/** Create an owned task in a calendar. */
+export async function createTask(input: CreateTaskInput): Promise<{ id: string }> {
+  const res = await apiFetch("/api/tasks", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const data = (await res.json().catch(() => ({}))) as { created?: { id: string }; error?: string };
+  if (!res.ok || !data.created) throw new Error(data.error ?? `create task failed: ${res.status}`);
+  return data.created;
+}
+
+export async function updateTask(id: string, patch: Partial<CreateTaskInput>): Promise<void> {
+  const res = await apiFetch(`/api/tasks/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) throw new Error(`update task failed: ${res.status}`);
+}
+
+export async function deleteTask(id: string): Promise<void> {
+  const res = await apiFetch(`/api/tasks/${encodeURIComponent(id)}`, { method: "DELETE" });
+  if (!res.ok) throw new Error(`delete task failed: ${res.status}`);
 }
 
 export function loginUrl(returnTo: string): string {

--- a/apps/portal/src/plugins/data.tsx
+++ b/apps/portal/src/plugins/data.tsx
@@ -1,5 +1,17 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
-import { getCalendar, getTasks, type CalendarEvent, type Task } from "@/lib/api";
+import {
+  createCalendar,
+  createEvent,
+  createTask,
+  getCalendar,
+  getTasks,
+  listCalendars,
+  type Calendar,
+  type CalendarEvent,
+  type CreateEventInput,
+  type CreateTaskInput,
+  type Task,
+} from "@/lib/api";
 import { SAMPLE_TASKS, sampleEvents } from "./sample-data";
 import type { CapabilityMap } from "@/components/plugin-slot";
 
@@ -10,7 +22,7 @@ import type { CapabilityMap } from "@/components/plugin-slot";
  * via context; the hooks fetch and pick live-vs-sample.
  */
 
-type Source = "github" | "sample";
+type Source = "github" | "sample" | "owned" | "owned+github";
 
 const Ctx = createContext<{ githubInstalled: boolean; nonce: number; refresh: () => void }>({
   githubInstalled: false,
@@ -30,32 +42,29 @@ export function usePluginDataRefresh(): () => void {
 }
 
 export function useTasks(): { tasks: Task[]; source: Source; loading: boolean } {
-  const { githubInstalled, nonce } = useContext(Ctx);
+  const { nonce } = useContext(Ctx);
   const [state, setState] = useState<{ tasks: Task[]; source: Source; loading: boolean }>({
     tasks: SAMPLE_TASKS,
     source: "sample",
-    loading: githubInstalled,
+    loading: true,
   });
 
   useEffect(() => {
-    if (!githubInstalled) {
-      setState({ tasks: SAMPLE_TASKS, source: "sample", loading: false });
-      return;
-    }
     let alive = true;
     setState((s) => ({ ...s, loading: true }));
+    // Always ask the server: it aggregates owned tasks (when signed in) with any
+    // connected source (GitHub). Only when nothing contributed do we show sample.
     getTasks()
       .then((r) => {
         if (!alive) return;
-        // Connected → show live data as-is (even if empty); else sample.
-        if (r.source) setState({ tasks: r.tasks, source: "github", loading: false });
+        if (r.source) setState({ tasks: r.tasks, source: r.source as Source, loading: false });
         else setState({ tasks: SAMPLE_TASKS, source: "sample", loading: false });
       })
       .catch(() => alive && setState({ tasks: SAMPLE_TASKS, source: "sample", loading: false }));
     return () => {
       alive = false;
     };
-  }, [githubInstalled, nonce]);
+  }, [nonce]);
 
   return state;
 }
@@ -63,17 +72,17 @@ export function useTasks(): { tasks: Task[]; source: Source; loading: boolean } 
 /**
  * Calendar fetch + sample fallback, decoupled from React so it can run inside a
  * host capability handler (sandboxed plugins call this via `ctx.call`, not a hook).
- * Connected → live GitHub data as-is; otherwise project-flavored sample events.
+ * The server aggregates the caller's owned calendars/events (#34) with any
+ * connected source (GitHub); only when nothing contributed do we show sample data.
  */
-async function fetchCalendarEvents(githubInstalled: boolean): Promise<{ events: CalendarEvent[]; source: Source }> {
-  if (!githubInstalled) return { events: sampleEvents(), source: "sample" };
+async function fetchCalendarEvents(): Promise<{ events: CalendarEvent[]; source: Source; calendars: Calendar[] }> {
   try {
     const r = await getCalendar();
-    if (r.source) return { events: r.events, source: "github" };
+    if (r.source || r.calendars.length) return { events: r.events, source: (r.source as Source) ?? "owned", calendars: r.calendars };
   } catch {
     // fall through to sample
   }
-  return { events: sampleEvents(), source: "sample" };
+  return { events: sampleEvents(), source: "sample", calendars: [] };
 }
 
 /**
@@ -81,11 +90,20 @@ async function fetchCalendarEvents(githubInstalled: boolean): Promise<{ events: 
  * Each entry is a method the host fulfils with its own credentials — the plugin
  * can only call what's wired here. Keyed by `<domain>.<verb>`; `nonce` lets a
  * settings change re-resolve on the next call.
+ *
+ * The `calendar.*` write verbs back the owned-calendar surface (#34): the plugin
+ * proposes a calendar/event/task and the host performs the credentialed write,
+ * scoped by the drive's folder-grant ACL server-side.
  */
 export function usePluginCapabilities(): CapabilityMap {
-  const { githubInstalled, nonce } = useContext(Ctx);
+  const { nonce } = useContext(Ctx);
   void nonce; // referenced so the map is rebuilt after a refresh()
   return {
-    "calendar.list": () => fetchCalendarEvents(githubInstalled),
+    "calendar.list": () => fetchCalendarEvents(),
+    "calendar.calendars": () => listCalendars(),
+    "calendar.createCalendar": (p) =>
+      createCalendar(p as { name: string; space?: string; path?: string; color?: string | null }),
+    "calendar.createEvent": (p) => createEvent(p as CreateEventInput),
+    "calendar.createTask": (p) => createTask(p as CreateTaskInput),
   };
 }

--- a/apps/portal/src/plugins/detail-views.tsx
+++ b/apps/portal/src/plugins/detail-views.tsx
@@ -12,11 +12,13 @@ const STATUS_META: Record<TaskStatus, { title: string; color: string }> = {
 const STATUS_ORDER: TaskStatus[] = ["todo", "in_progress", "blocked", "done"];
 
 /** A small pill telling the user whether they're seeing live or sample data. */
-function SourcePill({ source }: { source: "github" | "sample" }) {
-  if (source === "github") {
+function SourcePill({ source }: { source: "github" | "sample" | "owned" | "owned+github" }) {
+  if (source !== "sample") {
+    const label =
+      source === "github" ? "Live from GitHub" : source === "owned" ? "Your data" : "Your data + GitHub";
     return (
       <span className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-2 py-0.5 text-[11.5px] font-medium text-primary">
-        <span className="size-1.5 rounded-full bg-primary" /> Live from GitHub
+        <span className="size-1.5 rounded-full bg-primary" /> {label}
       </span>
     );
   }

--- a/documentation/08-sharing-and-spaces.md
+++ b/documentation/08-sharing-and-spaces.md
@@ -87,6 +87,24 @@ Keeping the tuples in **one store** is deliberate: an authorization check is inh
 cross-cutting, so it stays a single query rather than fanning out across databases. Content
 (files, blobs) can shard per space later; the authz graph stays centralized.
 
+## One model, many item types: calendars
+
+Folders and folder grants aren't just for files. A **calendar is a virtual folder**
+([Calendar](plugin-calendar)): creating a calendar creates a colored folder in a space, and
+its events and tasks are stored at that folder's path. Because the permission unit is the
+folder, **sharing a calendar is exactly sharing a folder** — grant a person (by email) or a
+whole group space `viewer`/`editor` on the calendar folder and they see its events, with the
+same downward inheritance as files.
+
+This is the payoff of keeping one identity + permission model: a single folder can hold a
+team's **documents and its calendar**, and one share covers both. Events and tasks live in
+their own tables (never as files), so they never appear in the file tree — they surface in
+the Calendar app instead — but they answer to the same `pathRole` check every file does. A
+space therefore has 0–n calendars (its calendar folders) plus an implicit root calendar.
+
+Tags on scheduling items (JSCalendar `keywords`) are classification only — for filtering and
+color — and carry no permission meaning; the folder decides who can see an item.
+
 ## Not yet
 
 - **Link sharing** ("anyone with the link") — planned (a tokenized grant with an optional

--- a/documentation/plugin-calendar.md
+++ b/documentation/plugin-calendar.md
@@ -1,26 +1,53 @@
 # Calendar
 
-A shared calendar surfaced as a full detail view and a right-rail **"Up next"** panel.
+A calendar surfaced as a full detail view and a right-rail **"Up next"** panel — over
+both your **own** calendars and any connected data source.
 
 ## What it does
 
-Calendar owns no data of its own — it reads events through the host's calendar capability
-and renders them. When a data source like [GitHub](plugin-github) is connected, it shows
-live events (releases, milestones); otherwise it falls back to project-flavoured sample
-data so the surface is never empty. A **"Add to calendar"** action appears in the context
-menu for documents, notes, and PDFs.
+Calendar renders an aggregated stream of events: your **owned** calendars (events you
+create and store in Canopy) plus live events from any connected [data source](how-plugins-work)
+like [GitHub](plugin-github) (releases, milestones). It owns no rendering data of its own —
+it reads the merged stream through the host's calendar capability. With nothing connected
+and nothing created, it falls back to project-flavoured sample data so the surface is never
+empty. A **"Add to calendar"** action appears in the context menu for documents, notes, and
+PDFs.
+
+## Calendars are folders
+
+A **calendar is a virtual folder** ([Sharing and spaces](sharing-and-spaces)). Creating a
+calendar creates a colored folder in a space; adding an event stores it at that folder's
+path. This means scheduling reuses the drive's identity and permission model wholesale:
+
+- **Sharing a calendar is a folder grant** — share it with specific people (by email) or
+  with a whole group space, exactly like sharing a folder of files, with the same downward
+  inheritance.
+- **A space has 0–n calendars** (its calendar folders) plus an **implicit root calendar**,
+  so "add an event to my Personal space" always has a home.
+- **Tags (`keywords`)** classify events for filtering and color; they carry no permission
+  meaning — that's the folder's job.
+
+Events and tasks live in their own tables, never as files, so they never show up in the
+drive's file tree — calendars are their own surface. But because a calendar folder can also
+hold documents, one share covers a folder's files *and* its scheduling items.
+
+The canonical record shape is [JSCalendar (RFC 8984)](https://www.rfc-editor.org/rfc/rfc8984):
+events and tasks are stored as JSCalendar objects, projected to the flat shape the plugin
+renders at read time — the same shape a future iCal/CalDAV import would up-convert to.
 
 ## At a glance
 
 - **Type:** App (sidebar detail view + right-rail panel)
 - **Contributes:** a detail view, a rail panel (`Calendar`), and a context-menu action
   (`Add to calendar`, on PDF / document / note items)
-- **Capabilities:** none of its own — reads events via the host
+- **Capabilities:** none of its own — reads the aggregated stream via the host
+- **Owns:** calendars (= folders), events, and tasks you create, stored in your spaces
 - **Availability:** in the store, **installed by default**
 - **Category:** Productivity
 
 ## See also
 
-- [Tasks](plugin-tasks) — its task-list sibling, fed by the same sources.
+- [Tasks](plugin-tasks) — its task-list sibling, fed by the same owned + connected sources.
 - [GitHub](plugin-github) — connect a repo to populate the calendar with live events.
+- [Sharing and spaces](sharing-and-spaces) — folders, folder grants, and how a calendar shares.
 - [How plugins work](how-plugins-work) — data sources and the rail/detail-view roles.

--- a/documentation/plugin-tasks.md
+++ b/documentation/plugin-tasks.md
@@ -4,10 +4,15 @@ A shared to-do list for the household, opened from the sidebar.
 
 ## What it does
 
-Tasks renders a typed list of to-dos as a detail view. Like [Calendar](plugin-calendar) it
-owns no data — it shows live tasks once a data source such as [GitHub](plugin-github) is
-connected (e.g. open issues), and project-flavoured sample tasks otherwise. From any file
-you can run **"Create task from file"** in the context menu to turn a document into a task.
+Tasks renders a typed list of to-dos as a detail view. It shows your **owned** tasks (work
+items you create, stored in a calendar — see [Calendar](plugin-calendar)) merged with live
+tasks from a connected data source such as [GitHub](plugin-github) (e.g. open issues), and
+project-flavoured sample tasks when there's nothing yet. From any file you can run **"Create
+task from file"** in the context menu to turn a document into a task.
+
+Owned tasks are JSCalendar Tasks: completion-bearing (a `status` and a `percentComplete`),
+with optional `start`/`due`. They live in a calendar (a virtual folder), so they inherit that
+folder's sharing — the same model as events.
 
 ## At a glance
 

--- a/examples/plugins/calendar/index.js
+++ b/examples/plugins/calendar/index.js
@@ -49,11 +49,13 @@ function title(ev, css) {
 }
 
 function sourcePill(source) {
-  if (source === "github") {
+  // Owned scheduling data (and GitHub feeds) are live; only "sample" is placeholder.
+  const liveLabel = { github: "Live from GitHub", owned: "Your calendar", "owned+github": "Your calendar · GitHub" }[source];
+  if (liveLabel) {
     const p = el(
       "span",
       "display:inline-flex;align-items:center;gap:6px;border-radius:999px;padding:2px 9px;font-size:11.5px;font-weight:500;background:hsl(var(--primary) / 0.1);color:hsl(var(--primary))",
-      "Live from GitHub",
+      liveLabel,
     );
     const dot = el("span", "width:6px;height:6px;border-radius:999px;background:hsl(var(--primary))");
     p.prepend(dot);

--- a/examples/plugins/calendar/index.js
+++ b/examples/plugins/calendar/index.js
@@ -4,11 +4,13 @@
 //   export function detailView(ctx)  — the full plugin page
 //   export function railPanel(ctx)    — the compact right-rail "Up next"
 //
-// It owns no data and makes no network calls. It asks the host for events via the
-// capability bridge — `await ctx.call("calendar.list")` → { events, source } — and
-// the host does the credentialed fetch (or sample fallback). Styling uses the host
-// theme tokens mirrored onto the frame (hsl(var(--token))), so it looks native
-// without importing the host's component library.
+// It asks the host for events via the capability bridge —
+// `await ctx.call("calendar.list")` → { events, source, calendars } — and the host
+// does the credentialed fetch (or sample fallback). Creating a calendar or event
+// goes through the same bridge (`calendar.createCalendar` / `calendar.createEvent`),
+// so the plugin never holds credentials and every write is ACL-checked server-side
+// (#34). Styling uses the host theme tokens mirrored onto the frame
+// (hsl(var(--token))), so it looks native without importing the host's components.
 //
 // ctx = { container, slot, call(method, params), emit(action, data) }
 
@@ -81,56 +83,185 @@ function groupByDay(events) {
   return groups;
 }
 
+/** A small native-looking button. */
+function button(label, onClick, opts = {}) {
+  const css = opts.primary
+    ? "border:none;border-radius:var(--radius);padding:6px 12px;font-size:12.5px;font-weight:500;cursor:pointer;background:hsl(var(--primary));color:hsl(var(--primary-foreground))"
+    : "border:1px solid hsl(var(--border));border-radius:var(--radius);padding:6px 12px;font-size:12.5px;font-weight:500;cursor:pointer;background:hsl(var(--card));color:hsl(var(--foreground))";
+  const b = el("button", css, label);
+  b.type = "button";
+  b.addEventListener("click", onClick);
+  return b;
+}
+
+function field(node, label) {
+  const wrap = el("label", "display:flex;flex-direction:column;gap:4px;font-size:11.5px;color:hsl(var(--muted-foreground))", label);
+  wrap.appendChild(node);
+  return wrap;
+}
+
+const INPUT_CSS =
+  "border:1px solid hsl(var(--border));border-radius:var(--radius);padding:6px 9px;font-size:13px;background:hsl(var(--background));color:hsl(var(--foreground))";
+
+function input(type, placeholder) {
+  const i = el("input", INPUT_CSS);
+  i.type = type;
+  if (placeholder) i.placeholder = placeholder;
+  return i;
+}
+
+/** A card-styled inline form with the given rows + a submit/cancel footer. */
+function formCard(title, rows, onSubmit, onCancel) {
+  const card = el(
+    "form",
+    "display:flex;flex-direction:column;gap:10px;border:1px solid hsl(var(--border));border-radius:var(--radius);background:hsl(var(--card));padding:14px",
+  );
+  card.appendChild(el("div", "font-size:13px;font-weight:600", title));
+  for (const r of rows) card.appendChild(r);
+  const foot = el("div", "display:flex;gap:8px;justify-content:flex-end");
+  const cancel = button("Cancel", onCancel);
+  const submit = button("Create", null, { primary: true });
+  submit.type = "submit";
+  foot.appendChild(cancel);
+  foot.appendChild(submit);
+  card.appendChild(foot);
+  card.addEventListener("submit", (e) => {
+    e.preventDefault();
+    onSubmit();
+  });
+  return card;
+}
+
 // ── detail view ──────────────────────────────────────────────────────────────
 export async function detailView(ctx) {
   const root = el("div", "display:flex;flex-direction:column;gap:14px;max-width:42rem");
   ctx.container.appendChild(root);
-  root.appendChild(el("div", "font-size:12px;color:hsl(var(--muted-foreground))", "Loading…"));
 
-  const { events, source } = await ctx.call("calendar.list");
-  root.replaceChildren(sourcePill(source));
-
-  const groups = groupByDay(events);
-  if (groups.length === 0) {
-    root.appendChild(
-      el(
-        "div",
-        "border:1px dashed hsl(var(--border));border-radius:var(--radius);padding:32px;text-align:center;font-size:13px;color:hsl(var(--muted-foreground))",
-        "No upcoming milestones or releases.",
-      ),
-    );
-    return;
+  async function reload() {
+    root.replaceChildren(el("div", "font-size:12px;color:hsl(var(--muted-foreground))", "Loading…"));
+    const [{ events, source }, calendars] = await Promise.all([
+      ctx.call("calendar.list"),
+      ctx.call("calendar.calendars").catch(() => []),
+    ]);
+    render(events, source, calendars || []);
   }
 
-  const list = el("div", "display:flex;flex-direction:column;gap:16px");
-  for (const g of groups) {
-    const row = el("div", "display:flex;gap:16px");
-    row.appendChild(
-      el("div", "width:7rem;flex:none;padding-top:4px;font-size:12.5px;font-weight:500;color:hsl(var(--muted-foreground))", g.day),
-    );
-    const items = el("div", "display:flex;flex-direction:column;gap:8px;flex:1");
-    for (const ev of g.items) {
-      const card = el(
-        "div",
-        "display:flex;align-items:center;gap:10px;border:1px solid hsl(var(--border));border-radius:var(--radius);background:hsl(var(--card));padding:10px",
+  function render(events, source, calendars) {
+    root.replaceChildren();
+
+    // Header: source pill + create actions.
+    const head = el("div", "display:flex;align-items:center;gap:10px;flex-wrap:wrap");
+    head.appendChild(sourcePill(source));
+    head.appendChild(el("div", "flex:1"));
+    const slot = el("div"); // inline forms render here
+    head.appendChild(button("New calendar", () => openCalendarForm()));
+    head.appendChild(button("New event", () => openEventForm(calendars), { primary: true }));
+    root.appendChild(head);
+    root.appendChild(slot);
+
+    function openCalendarForm() {
+      const name = input("text", "e.g. Work, Family");
+      slot.replaceChildren(
+        formCard(
+          "New calendar",
+          [field(name, "Name")],
+          async () => {
+            if (!name.value.trim()) return;
+            await ctx.call("calendar.createCalendar", { name: name.value.trim() });
+            await reload();
+          },
+          () => slot.replaceChildren(),
+        ),
       );
-      card.appendChild(toneBar(ev, 32));
-      card.appendChild(title(ev, "flex:1;min-width:0;font-size:13.5px;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"));
-      if (ev.kind) {
-        card.appendChild(
-          el(
-            "span",
-            "border:1px solid hsl(var(--border));border-radius:999px;padding:1px 8px;font-size:10.5px;color:hsl(var(--muted-foreground))",
-            KIND_LABEL[ev.kind] || ev.kind,
-          ),
-        );
-      }
-      items.appendChild(card);
+      name.focus();
     }
-    row.appendChild(items);
-    list.appendChild(row);
+
+    function openEventForm(cals) {
+      const titleIn = input("text", "Event title");
+      const startIn = input("datetime-local", "");
+      const sel = el("select", INPUT_CSS);
+      // First option = the personal root calendar (no specific folder).
+      const root0 = el("option", "", "My calendar");
+      root0.value = "";
+      sel.appendChild(root0);
+      for (const cal of cals) {
+        const o = el("option", "", `${cal.name}`);
+        o.value = cal.id; // `${spaceId}${path}`
+        sel.appendChild(o);
+      }
+      slot.replaceChildren(
+        formCard(
+          "New event",
+          [field(titleIn, "Title"), field(startIn, "Starts"), field(sel, "Calendar")],
+          async () => {
+            if (!titleIn.value.trim()) return;
+            const cal = cals.find((c) => c.id === sel.value);
+            const start = startIn.value ? new Date(startIn.value).toISOString() : undefined;
+            await ctx.call("calendar.createEvent", {
+              title: titleIn.value.trim(),
+              start,
+              space: cal ? cal.spaceId : undefined,
+              path: cal ? cal.path : undefined,
+            });
+            await reload();
+          },
+          () => slot.replaceChildren(),
+        ),
+      );
+      titleIn.focus();
+    }
+
+    const groups = groupByDay(events);
+    if (groups.length === 0) {
+      root.appendChild(
+        el(
+          "div",
+          "border:1px dashed hsl(var(--border));border-radius:var(--radius);padding:32px;text-align:center;font-size:13px;color:hsl(var(--muted-foreground))",
+          "Nothing scheduled yet. Create a calendar, then add an event.",
+        ),
+      );
+      return;
+    }
+
+    const list = el("div", "display:flex;flex-direction:column;gap:16px");
+    for (const g of groups) {
+      const row = el("div", "display:flex;gap:16px");
+      row.appendChild(
+        el("div", "width:7rem;flex:none;padding-top:4px;font-size:12.5px;font-weight:500;color:hsl(var(--muted-foreground))", g.day),
+      );
+      const items = el("div", "display:flex;flex-direction:column;gap:8px;flex:1");
+      for (const ev of g.items) {
+        const card = el(
+          "div",
+          "display:flex;align-items:center;gap:10px;border:1px solid hsl(var(--border));border-radius:var(--radius);background:hsl(var(--card));padding:10px",
+        );
+        // Owned events carry a per-calendar color; provider events fall back to tone.
+        card.appendChild(eventBar(ev, 32));
+        card.appendChild(title(ev, "flex:1;min-width:0;font-size:13.5px;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"));
+        if (ev.kind) {
+          card.appendChild(
+            el(
+              "span",
+              "border:1px solid hsl(var(--border));border-radius:999px;padding:1px 8px;font-size:10.5px;color:hsl(var(--muted-foreground))",
+              KIND_LABEL[ev.kind] || ev.kind,
+            ),
+          );
+        }
+        items.appendChild(card);
+      }
+      row.appendChild(items);
+      list.appendChild(row);
+    }
+    root.appendChild(list);
   }
-  root.appendChild(list);
+
+  await reload();
+}
+
+/** Accent bar for an event: a calendar's own color (owned) or its tone (provider). */
+function eventBar(ev, h) {
+  const color = ev.color || toneOf(ev.tone);
+  return el("span", `width:3px;height:${h}px;flex:none;border-radius:999px;background:hsl(${color})`);
 }
 
 // ── rail panel ───────────────────────────────────────────────────────────────

--- a/packages/core/src/providers.ts
+++ b/packages/core/src/providers.ts
@@ -21,6 +21,35 @@ export interface CalendarEvent {
   url?: string;
   /** Optional accent token (matches the host's TONE_COLOR keys). */
   tone?: string;
+  /**
+   * Which calendar this event belongs to — present for owned events (#34) so the
+   * aggregator can group, color, and toggle by calendar. A calendar is a virtual
+   * folder, so the coordinates are the space id + folder path. Absent for external
+   * provider events (GitHub etc.) that aren't space-scoped.
+   */
+  spaceId?: string;
+  /** Calendar folder path within the space ("" = the space's root calendar). */
+  path?: string;
+  /** The calendar (folder) id = `${spaceId}${path}`. */
+  calendarId?: string;
+  /** Per-calendar accent color (HSL triplet) when set on the calendar folder. */
+  color?: string;
+  /** Whether the caller may edit this event (owned + editor on its calendar). */
+  editable?: boolean;
+}
+
+/** A calendar: a shareable virtual folder of scheduling items (#34). */
+export interface Calendar {
+  /** Stable id = `${spaceId}${path}`. */
+  id: string;
+  spaceId: string;
+  /** Virtual-folder path within the space ("" = the implicit root calendar). */
+  path: string;
+  name: string;
+  /** Accent color (HSL triplet), or null to inherit the space color. */
+  color?: string | null;
+  /** The caller's role on this calendar: viewer | editor | owner. */
+  role: "viewer" | "editor" | "owner";
 }
 
 export interface CalendarRange {
@@ -51,6 +80,12 @@ export interface Task {
   priority?: "low" | "normal" | "high";
   /** Deep link back to the source (e.g. the GitHub issue URL). */
   url?: string;
+  /** Owned tasks (#34): the calendar (folder) the task lives in. */
+  spaceId?: string;
+  path?: string;
+  calendarId?: string;
+  /** Whether the caller may edit this task. */
+  editable?: boolean;
 }
 
 export interface TaskProvider {

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -27,5 +27,6 @@ export * from "./plugin-installs";
 export * from "./custom-plugins";
 export * from "./space-plugins";
 export * from "./files";
+export * from "./scheduling";
 export * from "./db-d1";
 export * from "./blob-r2";

--- a/packages/store/src/scheduling.test.ts
+++ b/packages/store/src/scheduling.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createLibsqlDb } from "./db-libsql";
+import { runMigrations } from "./schema";
+import { PermissionError } from "./files";
+import { addMember, createSpace, ensurePersonalSpace } from "./spaces";
+import { upsertUser } from "./users";
+import { SchedulingStore } from "./scheduling";
+import type { Db } from "./db";
+
+let db: Db;
+let store: SchedulingStore;
+const maya = { sub: "maya", email: "maya@x.com" };
+const daniel = { sub: "daniel", email: "daniel@x.com" };
+let personal: string;
+
+beforeEach(async () => {
+  db = createLibsqlDb(":memory:");
+  await runMigrations(db);
+  await upsertUser(db, { sub: "maya", email: "maya@x.com" });
+  await upsertUser(db, { sub: "daniel", email: "daniel@x.com" });
+  personal = await ensurePersonalSpace(db, "maya");
+  store = new SchedulingStore(db);
+});
+
+describe("calendars (= virtual folders)", () => {
+  it("creates a calendar and lists it back", async () => {
+    const cal = await store.createCalendar(maya, { spaceId: personal, name: "Work", color: "212 92% 50%" });
+    expect(cal.path).toBe("Work");
+    expect(cal.name).toBe("Work");
+    expect(cal.role).toBe("owner");
+    const list = await store.listCalendars(maya, personal);
+    expect(list.map((c) => c.name)).toContain("Work");
+  });
+
+  it("re-creating a calendar updates name/color (idempotent on path)", async () => {
+    await store.createCalendar(maya, { spaceId: personal, name: "Work", path: "work" });
+    await store.createCalendar(maya, { spaceId: personal, name: "Job", path: "work", color: "0 0% 0%" });
+    const list = await store.listCalendars(maya, personal);
+    const work = list.find((c) => c.path === "work")!;
+    expect(work.name).toBe("Job");
+    expect(work.color).toBe("0 0% 0%");
+  });
+});
+
+describe("events", () => {
+  it("creates an event in a calendar and finds it in range", async () => {
+    await store.createCalendar(maya, { spaceId: personal, name: "Work", path: "work" });
+    const ev = await store.createEvent(maya, {
+      spaceId: personal,
+      path: "work",
+      title: "Standup",
+      start: "2026-07-01T09:00:00Z",
+      end: "2026-07-01T09:30:00Z",
+    });
+    expect(ev.title).toBe("Standup");
+    expect(ev.etag).toMatch(/^[0-9a-f]{64}$/);
+    const inRange = await store.listEvents(maya, {
+      spaceId: personal,
+      range: { from: "2026-07-01T00:00:00Z", to: "2026-07-02T00:00:00Z" },
+    });
+    expect(inRange.map((e) => e.id)).toContain(ev.id);
+    const outOfRange = await store.listEvents(maya, {
+      spaceId: personal,
+      range: { from: "2026-08-01T00:00:00Z", to: "2026-08-02T00:00:00Z" },
+    });
+    expect(outOfRange.map((e) => e.id)).not.toContain(ev.id);
+  });
+
+  it("updates and soft-deletes an event", async () => {
+    const ev = await store.createEvent(maya, { spaceId: personal, path: "", title: "Draft", start: "2026-07-01T09:00:00Z" });
+    const updated = await store.updateEvent(maya, ev.id, { title: "Final" });
+    expect(updated.title).toBe("Final");
+    expect(updated.etag).not.toBe(ev.etag);
+    await store.deleteEvent(maya, ev.id);
+    expect(await store.getEvent(maya, ev.id)).toBeNull();
+  });
+});
+
+describe("tasks", () => {
+  it("creates and completes a task", async () => {
+    const t = await store.createTask(maya, { spaceId: personal, title: "Ship it", due: "2026-07-05" });
+    expect(t.status).toBe("todo");
+    const done = await store.updateTask(maya, t.id, { status: "done", progress: 100 });
+    expect(done.status).toBe("done");
+    expect(done.progress).toBe(100);
+    const list = await store.listTasks(maya, { spaceId: personal });
+    expect(list.map((x) => x.id)).toContain(t.id);
+  });
+});
+
+describe("permissions reuse folder grants", () => {
+  it("a non-member cannot read another user's calendar", async () => {
+    await store.createCalendar(maya, { spaceId: personal, name: "Private", path: "private" });
+    const ev = await store.createEvent(maya, { spaceId: personal, path: "private", title: "Secret", start: "2026-07-01T09:00:00Z" });
+    await expect(store.getEvent(daniel, ev.id)).rejects.toBeInstanceOf(PermissionError);
+    const danielSees = await store.listEvents(daniel, {
+      spaceId: personal,
+      range: { from: "2026-07-01T00:00:00Z", to: "2026-07-02T00:00:00Z" },
+    });
+    expect(danielSees).toHaveLength(0);
+  });
+
+  it("sharing a calendar folder grants a person access to its events", async () => {
+    await store.createCalendar(maya, { spaceId: personal, name: "Family", path: "family" });
+    const ev = await store.createEvent(maya, { spaceId: personal, path: "family", title: "Dinner", start: "2026-07-01T18:00:00Z" });
+    await store.shareCalendar(maya, personal, "family", "daniel@x.com", "viewer");
+    const seen = await store.getEvent(daniel, ev.id);
+    expect(seen?.title).toBe("Dinner");
+  });
+
+  it("group-space members see a space calendar's events", async () => {
+    const fam = await createSpace(db, { name: "Household", createdBy: "maya" });
+    // Add daniel as an editor of the group space.
+    await addMember(db, fam.id, "daniel", "editor");
+    await store.createCalendar(maya, { spaceId: fam.id, name: "Shared", path: "shared" });
+    const ev = await store.createEvent(maya, { spaceId: fam.id, path: "shared", title: "Cleanup", start: "2026-07-01T10:00:00Z" });
+    const seen = await store.getEvent(daniel, ev.id);
+    expect(seen?.id).toBe(ev.id);
+  });
+});
+
+describe("participants", () => {
+  it("attaches a principal to an event", async () => {
+    const ev = await store.createEvent(maya, { spaceId: personal, path: "", title: "Sync", start: "2026-07-01T09:00:00Z" });
+    const p = await store.upsertPrincipal(maya, { spaceId: personal, email: "guest@x.com", name: "Guest" });
+    await store.addParticipant(maya, ev.id, p.id, { role: "attendee" });
+    const parts = await store.listParticipants(maya, ev.id);
+    expect(parts.map((x) => x.email)).toContain("guest@x.com");
+  });
+});

--- a/packages/store/src/scheduling.test.ts
+++ b/packages/store/src/scheduling.test.ts
@@ -54,11 +54,19 @@ describe("events", () => {
     });
     expect(ev.title).toBe("Standup");
     expect(ev.etag).toMatch(/^[0-9a-f]{64}$/);
+    // A point-in-time event (no end) before the window must NOT leak into a later range.
+    const evPoint = await store.createEvent(maya, {
+      spaceId: personal,
+      path: "work",
+      title: "Kickoff",
+      start: "2026-06-15T09:00:00Z",
+    });
     const inRange = await store.listEvents(maya, {
       spaceId: personal,
       range: { from: "2026-07-01T00:00:00Z", to: "2026-07-02T00:00:00Z" },
     });
     expect(inRange.map((e) => e.id)).toContain(ev.id);
+    expect(inRange.map((e) => e.id)).not.toContain(evPoint.id);
     const outOfRange = await store.listEvents(maya, {
       spaceId: personal,
       range: { from: "2026-08-01T00:00:00Z", to: "2026-08-02T00:00:00Z" },

--- a/packages/store/src/scheduling.ts
+++ b/packages/store/src/scheduling.ts
@@ -1,0 +1,576 @@
+/**
+ * Scheduling store — calendars, events, tasks, and principals (#34).
+ *
+ * The design principle: scheduling data **reuses the drive's identity and
+ * permission model** rather than inventing its own. A *calendar is a virtual
+ * folder* (a row in `folders` with `kind='calendar'`), so sharing a calendar is
+ * just a folder grant and every permission check routes through {@link pathRole}
+ * exactly like files do. Events and tasks live in their own tables — never
+ * `files` — so they don't appear in drive listings, but they carry the same
+ * `tenant_id` (space) + `path` (calendar folder) coordinates, which means one
+ * folder grant covers a folder's documents *and* its scheduling items.
+ *
+ * JSCalendar (RFC 8984) is the canonical record shape: the full object is stored
+ * verbatim in the `jscal` column, with a handful of fields (title, start, due,
+ * status, …) lifted into columns for indexed range/status queries. The flat
+ * shapes the host plugins render ({@link CalendarEvent} / {@link Task} from
+ * `@canopy/core`) are a *projection* produced at the read boundary.
+ *
+ * This store is runtime-agnostic ({@link Db} only) and does its own authorization
+ * via the exported authz helpers, so it never needs the `FileService`'s private
+ * internals.
+ */
+
+import {
+  ROLE_RANK,
+  folderObjectId,
+  memberSpaceIds,
+  pathRole,
+  sharedFolders,
+  writeTuple,
+} from "./authz";
+import type { Db } from "./db";
+import { PermissionError } from "./files";
+import { sha256hex } from "./hash";
+import type { Caller } from "./files";
+import type { Role } from "./types";
+
+const enc = new TextEncoder();
+const now = () => new Date().toISOString();
+const etagOf = (jscal: unknown) => sha256hex(enc.encode(JSON.stringify(jscal)));
+
+/** Normalize a calendar/folder path the same way the drive does (no leading/trailing slash). */
+function normPath(path: string): string {
+  return path.replace(/^\/+|\/+$/g, "").replace(/\/{2,}/g, "/");
+}
+
+/* ── public shapes ─────────────────────────────────────────────────────────── */
+
+/** A calendar: a shareable virtual folder of scheduling items. */
+export interface Calendar {
+  /** Stable id = `${spaceId}${path}` (the folder object id). */
+  id: string;
+  spaceId: string;
+  /** Virtual-folder path within the space (e.g. "Work"). "" is the implicit root calendar. */
+  path: string;
+  name: string;
+  /** Accent color — an HSL triplet like "145 33% 36%", or null to inherit the space color. */
+  color: string | null;
+  /** The caller's effective role on this calendar (folder grant ∪ space membership). */
+  role: Role;
+  createdAt?: string;
+}
+
+export interface EventInput {
+  spaceId: string;
+  /** Calendar folder path; "" targets the space's root calendar. */
+  path?: string;
+  title: string;
+  /** ISO 8601 (date or date-time). */
+  start?: string | null;
+  end?: string | null;
+  allDay?: boolean;
+  description?: string | null;
+  location?: string | null;
+  keywords?: string[];
+  /** Extra JSCalendar properties merged into the stored object. */
+  jscal?: Record<string, unknown>;
+}
+
+export interface EventRecord {
+  id: string;
+  spaceId: string;
+  path: string;
+  uid: string;
+  title: string;
+  start: string | null;
+  end: string | null;
+  allDay: boolean;
+  description: string | null;
+  location: string | null;
+  keywords: string[];
+  etag: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type TaskStatus = "todo" | "in_progress" | "blocked" | "done";
+
+export interface TaskInput {
+  spaceId: string;
+  path?: string;
+  title: string;
+  status?: TaskStatus;
+  progress?: number | null;
+  start?: string | null;
+  due?: string | null;
+  priority?: "low" | "normal" | "high" | null;
+  keywords?: string[];
+  jscal?: Record<string, unknown>;
+}
+
+export interface TaskRecord {
+  id: string;
+  spaceId: string;
+  path: string;
+  uid: string;
+  title: string;
+  status: TaskStatus;
+  progress: number | null;
+  start: string | null;
+  due: string | null;
+  priority: string | null;
+  keywords: string[];
+  etag: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Range {
+  from: string;
+  to: string;
+}
+
+export interface Principal {
+  id: string;
+  spaceId: string | null;
+  kind: string;
+  sub: string | null;
+  email: string | null;
+  name: string | null;
+}
+
+/* ── row → shape mappers ───────────────────────────────────────────────────── */
+
+interface EventRow {
+  id: string;
+  tenant_id: string;
+  path: string;
+  owner_id: string;
+  uid: string;
+  title: string;
+  start: string | null;
+  end: string | null;
+  all_day: number;
+  description: string | null;
+  location: string | null;
+  keywords: string | null;
+  jscal: string;
+  etag: string;
+  created_at: string;
+  updated_at: string;
+}
+
+const parseKeywords = (s: string | null): string[] => {
+  if (!s) return [];
+  try {
+    const v = JSON.parse(s);
+    return Array.isArray(v) ? v.map(String) : [];
+  } catch {
+    return [];
+  }
+};
+
+function toEvent(r: EventRow): EventRecord {
+  return {
+    id: r.id,
+    spaceId: r.tenant_id,
+    path: r.path,
+    uid: r.uid,
+    title: r.title,
+    start: r.start,
+    end: r.end,
+    allDay: r.all_day === 1,
+    description: r.description,
+    location: r.location,
+    keywords: parseKeywords(r.keywords),
+    etag: r.etag,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+interface TaskRow {
+  id: string;
+  tenant_id: string;
+  path: string;
+  owner_id: string;
+  uid: string;
+  title: string;
+  status: string;
+  progress: number | null;
+  start: string | null;
+  due: string | null;
+  priority: string | null;
+  keywords: string | null;
+  jscal: string;
+  etag: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function toTask(r: TaskRow): TaskRecord {
+  return {
+    id: r.id,
+    spaceId: r.tenant_id,
+    path: r.path,
+    uid: r.uid,
+    title: r.title,
+    status: (r.status as TaskStatus) ?? "todo",
+    progress: r.progress,
+    start: r.start,
+    due: r.due,
+    priority: r.priority,
+    keywords: parseKeywords(r.keywords),
+    etag: r.etag,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+/* ── the store ─────────────────────────────────────────────────────────────── */
+
+export class SchedulingStore {
+  constructor(private readonly db: Db) {}
+
+  /** Throw unless the caller holds at least `required` on `path` in `spaceId`. */
+  private async requirePath(caller: Caller, spaceId: string, path: string, required: Role): Promise<void> {
+    const role = await pathRole(this.db, spaceId, normPath(path), caller.sub, caller.email ?? "");
+    if (!role || ROLE_RANK[role] < ROLE_RANK[required]) throw new PermissionError();
+  }
+
+  /* ── calendars (= virtual folders) ──────────────────────────────────────── */
+
+  /**
+   * Create a calendar in a space: a `folders` row tagged `kind='calendar'` with a
+   * display name + color. Idempotent on (space, path) — re-creating updates the
+   * name/color. Requires editor on the target path.
+   */
+  async createCalendar(
+    caller: Caller,
+    input: { spaceId: string; name: string; path?: string; color?: string | null },
+  ): Promise<Calendar> {
+    const path = normPath(input.path ?? input.name);
+    if (!path) throw new Error("calendar path required");
+    await this.requirePath(caller, input.spaceId, path, "editor");
+    await this.db.run(
+      `INSERT INTO folders (space_id, path, created_at, name, color, kind)
+         VALUES (?, ?, ?, ?, ?, 'calendar')
+       ON CONFLICT(space_id, path) DO UPDATE SET name = excluded.name, color = excluded.color, kind = 'calendar'`,
+      [input.spaceId, path, now(), input.name, input.color ?? null],
+    );
+    const role = (await pathRole(this.db, input.spaceId, path, caller.sub, caller.email ?? "")) ?? "viewer";
+    return { id: folderObjectId(input.spaceId, path), spaceId: input.spaceId, path, name: input.name, color: input.color ?? null, role };
+  }
+
+  /**
+   * Calendars the caller can see: every `kind='calendar'` folder in a space they
+   * belong to, plus folders shared directly with them. Optionally scoped to one
+   * space.
+   */
+  async listCalendars(caller: Caller, spaceId?: string): Promise<Calendar[]> {
+    const spaceIds = spaceId ? [spaceId] : await memberSpaceIds(this.db, caller.sub);
+    const out: Calendar[] = [];
+    const seen = new Set<string>();
+
+    for (const sid of spaceIds) {
+      const rows = await this.db.all<{ space_id: string; path: string; name: string | null; color: string | null; created_at: string }>(
+        `SELECT space_id, path, name, color, created_at FROM folders WHERE space_id = ? AND kind = 'calendar' ORDER BY name`,
+        [sid],
+      );
+      for (const r of rows) {
+        const role = await pathRole(this.db, r.space_id, r.path, caller.sub, caller.email ?? "");
+        if (!role) continue;
+        const id = folderObjectId(r.space_id, r.path);
+        seen.add(id);
+        out.push({ id, spaceId: r.space_id, path: r.path, name: r.name ?? r.path, color: r.color, role, createdAt: r.created_at });
+      }
+    }
+
+    // Calendars shared directly with the caller (folder grants), even outside a
+    // space they're a member of — "shared with me".
+    if (!spaceId) {
+      const shared = await sharedFolders(this.db, caller.sub);
+      for (const s of shared) {
+        const id = folderObjectId(s.spaceId, s.path);
+        if (seen.has(id)) continue;
+        const row = await this.db.first<{ name: string | null; color: string | null }>(
+          `SELECT name, color FROM folders WHERE space_id = ? AND path = ? AND kind = 'calendar'`,
+          [s.spaceId, s.path],
+        );
+        if (!row) continue; // shared folder that isn't a calendar
+        seen.add(id);
+        out.push({ id, spaceId: s.spaceId, path: s.path, name: row.name ?? s.path, color: row.color, role: s.role });
+      }
+    }
+    return out;
+  }
+
+  /** Share a calendar (folder) with a person by email — a viewer/editor folder grant. */
+  async shareCalendar(caller: Caller, spaceId: string, path: string, email: string, role: Role): Promise<void> {
+    await this.requirePath(caller, spaceId, path, "owner");
+    await writeTuple(this.db, {
+      objectType: "folder",
+      objectId: folderObjectId(spaceId, normPath(path)),
+      relation: role,
+      subjectType: "email",
+      subjectId: email.trim().toLowerCase(),
+    });
+  }
+
+  /* ── events ─────────────────────────────────────────────────────────────── */
+
+  async createEvent(caller: Caller, input: EventInput): Promise<EventRecord> {
+    const path = normPath(input.path ?? "");
+    await this.requirePath(caller, input.spaceId, path, "editor");
+    const id = crypto.randomUUID();
+    const uid = `${id}@canopy`;
+    const ts = now();
+    const allDay = input.allDay ?? false;
+    const jscal = {
+      "@type": "Event",
+      uid,
+      title: input.title,
+      start: input.start ?? undefined,
+      ...(input.end ? { end: input.end } : {}),
+      ...(allDay ? { showWithoutTime: true } : {}),
+      ...(input.description ? { description: input.description } : {}),
+      ...(input.location ? { locations: { l1: { name: input.location } } } : {}),
+      ...(input.keywords?.length ? { keywords: Object.fromEntries(input.keywords.map((k) => [k, true])) } : {}),
+      ...(input.jscal ?? {}),
+    };
+    const etag = await etagOf(jscal);
+    await this.db.run(
+      `INSERT INTO events (id, tenant_id, path, owner_id, uid, title, start, end, all_day, description, location, keywords, jscal, etag, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id, input.spaceId, path, caller.sub, uid, input.title, input.start ?? null, input.end ?? null,
+        allDay ? 1 : 0, input.description ?? null, input.location ?? null,
+        input.keywords?.length ? JSON.stringify(input.keywords) : null, JSON.stringify(jscal), etag, ts, ts,
+      ],
+    );
+    return (await this.getEvent(caller, id))!;
+  }
+
+  async getEvent(caller: Caller, id: string): Promise<EventRecord | null> {
+    const row = await this.db.first<EventRow>(`SELECT * FROM events WHERE id = ? AND deleted_at IS NULL`, [id]);
+    if (!row) return null;
+    await this.requirePath(caller, row.tenant_id, row.path, "viewer");
+    return toEvent(row);
+  }
+
+  /**
+   * Events the caller can see in `[from, to)`. Without `spaceId` it spans every
+   * space the caller belongs to; `calendars` (paths) narrows to specific calendars.
+   */
+  async listEvents(
+    caller: Caller,
+    opts: { range: Range; spaceId?: string; calendars?: string[] },
+  ): Promise<EventRecord[]> {
+    const spaceIds = opts.spaceId ? [opts.spaceId] : await memberSpaceIds(this.db, caller.sub);
+    const out: EventRecord[] = [];
+    for (const sid of spaceIds) {
+      const rows = await this.db.all<EventRow>(
+        `SELECT * FROM events
+           WHERE tenant_id = ? AND deleted_at IS NULL
+             AND (start IS NULL OR (start < ? AND (end IS NULL OR end >= ?) OR start >= ? AND start < ?))
+           ORDER BY start`,
+        [sid, opts.range.to, opts.range.from, opts.range.from, opts.range.to],
+      );
+      for (const r of rows) {
+        if (opts.calendars && !opts.calendars.includes(r.path)) continue;
+        const role = await pathRole(this.db, r.tenant_id, r.path, caller.sub, caller.email ?? "");
+        if (!role) continue;
+        out.push(toEvent(r));
+      }
+    }
+    return out.sort((a, b) => (a.start ?? "").localeCompare(b.start ?? ""));
+  }
+
+  async updateEvent(caller: Caller, id: string, patch: Partial<EventInput>): Promise<EventRecord> {
+    const row = await this.db.first<EventRow>(`SELECT * FROM events WHERE id = ? AND deleted_at IS NULL`, [id]);
+    if (!row) throw new Error("event not found");
+    await this.requirePath(caller, row.tenant_id, row.path, "editor");
+    const merged: EventRecord = { ...toEvent(row), ...stripUndefined(patch) } as EventRecord;
+    const jscal = { ...(JSON.parse(row.jscal) as Record<string, unknown>) };
+    if (patch.title !== undefined) jscal.title = patch.title;
+    if (patch.start !== undefined) jscal.start = patch.start ?? undefined;
+    if (patch.end !== undefined) jscal.end = patch.end ?? undefined;
+    if (patch.description !== undefined) jscal.description = patch.description ?? undefined;
+    if (patch.keywords !== undefined)
+      jscal.keywords = patch.keywords?.length ? Object.fromEntries(patch.keywords.map((k) => [k, true])) : undefined;
+    const etag = await etagOf(jscal);
+    const allDay = patch.allDay ?? merged.allDay;
+    await this.db.run(
+      `UPDATE events SET title = ?, start = ?, end = ?, all_day = ?, description = ?, location = ?, keywords = ?, jscal = ?, etag = ?, updated_at = ?
+         WHERE id = ?`,
+      [
+        merged.title, merged.start ?? null, merged.end ?? null, allDay ? 1 : 0, merged.description ?? null,
+        merged.location ?? null, merged.keywords.length ? JSON.stringify(merged.keywords) : null,
+        JSON.stringify(jscal), etag, now(), id,
+      ],
+    );
+    return (await this.getEvent(caller, id))!;
+  }
+
+  async deleteEvent(caller: Caller, id: string): Promise<void> {
+    const row = await this.db.first<EventRow>(`SELECT tenant_id, path FROM events WHERE id = ? AND deleted_at IS NULL`, [id]);
+    if (!row) return;
+    await this.requirePath(caller, row.tenant_id, row.path, "editor");
+    await this.db.run(`UPDATE events SET deleted_at = ? WHERE id = ?`, [now(), id]);
+  }
+
+  /* ── tasks ──────────────────────────────────────────────────────────────── */
+
+  async createTask(caller: Caller, input: TaskInput): Promise<TaskRecord> {
+    const path = normPath(input.path ?? "");
+    await this.requirePath(caller, input.spaceId, path, "editor");
+    const id = crypto.randomUUID();
+    const uid = `${id}@canopy`;
+    const ts = now();
+    const status = input.status ?? "todo";
+    const jscal = {
+      "@type": "Task",
+      uid,
+      title: input.title,
+      progress: status === "done" ? "completed" : status === "in_progress" ? "in-process" : "needs-action",
+      ...(input.progress != null ? { percentComplete: input.progress } : {}),
+      ...(input.start ? { start: input.start } : {}),
+      ...(input.due ? { due: input.due } : {}),
+      ...(input.keywords?.length ? { keywords: Object.fromEntries(input.keywords.map((k) => [k, true])) } : {}),
+      ...(input.jscal ?? {}),
+    };
+    const etag = await etagOf(jscal);
+    await this.db.run(
+      `INSERT INTO tasks (id, tenant_id, path, owner_id, uid, title, status, progress, start, due, priority, keywords, jscal, etag, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id, input.spaceId, path, caller.sub, uid, input.title, status, input.progress ?? null,
+        input.start ?? null, input.due ?? null, input.priority ?? null,
+        input.keywords?.length ? JSON.stringify(input.keywords) : null, JSON.stringify(jscal), etag, ts, ts,
+      ],
+    );
+    return (await this.getTask(caller, id))!;
+  }
+
+  async getTask(caller: Caller, id: string): Promise<TaskRecord | null> {
+    const row = await this.db.first<TaskRow>(`SELECT * FROM tasks WHERE id = ? AND deleted_at IS NULL`, [id]);
+    if (!row) return null;
+    await this.requirePath(caller, row.tenant_id, row.path, "viewer");
+    return toTask(row);
+  }
+
+  async listTasks(caller: Caller, opts: { spaceId?: string; calendars?: string[] } = {}): Promise<TaskRecord[]> {
+    const spaceIds = opts.spaceId ? [opts.spaceId] : await memberSpaceIds(this.db, caller.sub);
+    const out: TaskRecord[] = [];
+    for (const sid of spaceIds) {
+      const rows = await this.db.all<TaskRow>(
+        `SELECT * FROM tasks WHERE tenant_id = ? AND deleted_at IS NULL ORDER BY due`,
+        [sid],
+      );
+      for (const r of rows) {
+        if (opts.calendars && !opts.calendars.includes(r.path)) continue;
+        const role = await pathRole(this.db, r.tenant_id, r.path, caller.sub, caller.email ?? "");
+        if (!role) continue;
+        out.push(toTask(r));
+      }
+    }
+    return out;
+  }
+
+  async updateTask(caller: Caller, id: string, patch: Partial<TaskInput>): Promise<TaskRecord> {
+    const row = await this.db.first<TaskRow>(`SELECT * FROM tasks WHERE id = ? AND deleted_at IS NULL`, [id]);
+    if (!row) throw new Error("task not found");
+    await this.requirePath(caller, row.tenant_id, row.path, "editor");
+    const merged: TaskRecord = { ...toTask(row), ...stripUndefined(patch) } as TaskRecord;
+    const jscal = { ...(JSON.parse(row.jscal) as Record<string, unknown>) };
+    if (patch.title !== undefined) jscal.title = patch.title;
+    if (patch.status !== undefined)
+      jscal.progress = patch.status === "done" ? "completed" : patch.status === "in_progress" ? "in-process" : "needs-action";
+    if (patch.progress !== undefined) jscal.percentComplete = patch.progress ?? undefined;
+    if (patch.due !== undefined) jscal.due = patch.due ?? undefined;
+    const etag = await etagOf(jscal);
+    await this.db.run(
+      `UPDATE tasks SET title = ?, status = ?, progress = ?, start = ?, due = ?, priority = ?, keywords = ?, jscal = ?, etag = ?, updated_at = ?
+         WHERE id = ?`,
+      [
+        merged.title, merged.status, merged.progress ?? null, merged.start ?? null, merged.due ?? null,
+        merged.priority ?? null, merged.keywords.length ? JSON.stringify(merged.keywords) : null,
+        JSON.stringify(jscal), etag, now(), id,
+      ],
+    );
+    return (await this.getTask(caller, id))!;
+  }
+
+  async deleteTask(caller: Caller, id: string): Promise<void> {
+    const row = await this.db.first<TaskRow>(`SELECT tenant_id, path FROM tasks WHERE id = ? AND deleted_at IS NULL`, [id]);
+    if (!row) return;
+    await this.requirePath(caller, row.tenant_id, row.path, "editor");
+    await this.db.run(`UPDATE tasks SET deleted_at = ? WHERE id = ?`, [now(), id]);
+  }
+
+  /* ── principals + participants ──────────────────────────────────────────── */
+
+  /** Find or create a person principal (by email within a space). */
+  async upsertPrincipal(
+    caller: Caller,
+    input: { spaceId: string; email?: string; name?: string; sub?: string },
+  ): Promise<Principal> {
+    await this.requirePath(caller, input.spaceId, "", "editor");
+    const email = input.email?.trim().toLowerCase() ?? null;
+    if (email) {
+      const existing = await this.db.first<{ id: string; sub: string | null; name: string | null }>(
+        `SELECT id, sub, name FROM principals WHERE tenant_id = ? AND email = ? AND kind = 'person'`,
+        [input.spaceId, email],
+      );
+      if (existing)
+        return { id: existing.id, spaceId: input.spaceId, kind: "person", sub: existing.sub, email, name: existing.name };
+    }
+    const id = crypto.randomUUID();
+    await this.db.run(
+      `INSERT INTO principals (id, tenant_id, kind, sub, email, name, created_at) VALUES (?, ?, 'person', ?, ?, ?, ?)`,
+      [id, input.spaceId, input.sub ?? null, email, input.name ?? null, now()],
+    );
+    return { id, spaceId: input.spaceId, kind: "person", sub: input.sub ?? null, email, name: input.name ?? null };
+  }
+
+  /** Attach a principal to an event as a participant. */
+  async addParticipant(
+    caller: Caller,
+    eventId: string,
+    principalId: string,
+    opts: { role?: string; status?: string } = {},
+  ): Promise<void> {
+    const ev = await this.db.first<{ tenant_id: string; path: string }>(
+      `SELECT tenant_id, path FROM events WHERE id = ? AND deleted_at IS NULL`,
+      [eventId],
+    );
+    if (!ev) throw new Error("event not found");
+    await this.requirePath(caller, ev.tenant_id, ev.path, "editor");
+    await this.db.run(
+      `INSERT INTO event_participants (event_id, principal_id, role, status) VALUES (?, ?, ?, ?)
+         ON CONFLICT(event_id, principal_id) DO UPDATE SET role = excluded.role, status = excluded.status`,
+      [eventId, principalId, opts.role ?? "attendee", opts.status ?? "needs-action"],
+    );
+  }
+
+  async listParticipants(caller: Caller, eventId: string): Promise<Principal[]> {
+    const ev = await this.db.first<{ tenant_id: string; path: string }>(
+      `SELECT tenant_id, path FROM events WHERE id = ? AND deleted_at IS NULL`,
+      [eventId],
+    );
+    if (!ev) return [];
+    await this.requirePath(caller, ev.tenant_id, ev.path, "viewer");
+    return this.db.all<Principal>(
+      `SELECT p.id, p.tenant_id AS spaceId, p.kind, p.sub, p.email, p.name
+         FROM event_participants ep JOIN principals p ON p.id = ep.principal_id
+        WHERE ep.event_id = ?`,
+      [eventId],
+    );
+  }
+}
+
+/** Drop keys whose value is `undefined` so a partial patch doesn't clobber with undefined. */
+function stripUndefined<T extends object>(obj: T): Partial<T> {
+  return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined)) as Partial<T>;
+}

--- a/packages/store/src/scheduling.ts
+++ b/packages/store/src/scheduling.ts
@@ -337,7 +337,7 @@ export class SchedulingStore {
       ...(input.description ? { description: input.description } : {}),
       ...(input.location ? { locations: { l1: { name: input.location } } } : {}),
       ...(input.keywords?.length ? { keywords: Object.fromEntries(input.keywords.map((k) => [k, true])) } : {}),
-      ...(input.jscal ?? {}),
+      ...omit(input.jscal, EVENT_MANAGED_KEYS),
     };
     const etag = await etagOf(jscal);
     await this.db.run(
@@ -366,14 +366,19 @@ export class SchedulingStore {
   async listEvents(
     caller: Caller,
     opts: { range: Range; spaceId?: string; calendars?: string[] },
-  ): Promise<EventRecord[]> {
-    const spaceIds = opts.spaceId ? [opts.spaceId] : await memberSpaceIds(this.db, caller.sub);
-    const out: EventRecord[] = [];
+  ): Promise<(EventRecord & { role: Role })[]> {
+    const spaceIds = await this.aggregateSpaceIds(caller, opts.spaceId);
+    const out: (EventRecord & { role: Role })[] = [];
     for (const sid of spaceIds) {
       const rows = await this.db.all<EventRow>(
+        // Ranged events (end set) overlap the window; point-in-time events (end
+        // NULL) match only when their start itself falls in [from, to). Undated
+        // events always surface.
         `SELECT * FROM events
            WHERE tenant_id = ? AND deleted_at IS NULL
-             AND (start IS NULL OR (start < ? AND (end IS NULL OR end >= ?) OR start >= ? AND start < ?))
+             AND (start IS NULL
+                  OR (end IS NOT NULL AND start < ? AND end >= ?)
+                  OR (end IS NULL AND start >= ? AND start < ?))
            ORDER BY start`,
         [sid, opts.range.to, opts.range.from, opts.range.from, opts.range.to],
       );
@@ -381,10 +386,22 @@ export class SchedulingStore {
         if (opts.calendars && !opts.calendars.includes(r.path)) continue;
         const role = await pathRole(this.db, r.tenant_id, r.path, caller.sub, caller.email ?? "");
         if (!role) continue;
-        out.push(toEvent(r));
+        out.push({ ...toEvent(r), role });
       }
     }
     return out.sort((a, b) => (a.start ?? "").localeCompare(b.start ?? ""));
+  }
+
+  /**
+   * Spaces to scan for an aggregate read: every space the caller belongs to, plus
+   * spaces reachable only through a direct folder share (calendars shared with the
+   * caller who isn't a member). Scoped to one space when `spaceId` is given.
+   */
+  private async aggregateSpaceIds(caller: Caller, spaceId?: string): Promise<string[]> {
+    if (spaceId) return [spaceId];
+    const member = await memberSpaceIds(this.db, caller.sub);
+    const shared = await sharedFolders(this.db, caller.sub);
+    return [...new Set([...member, ...shared.map((s) => s.spaceId)])];
   }
 
   async updateEvent(caller: Caller, id: string, patch: Partial<EventInput>): Promise<EventRecord> {
@@ -397,6 +414,9 @@ export class SchedulingStore {
     if (patch.start !== undefined) jscal.start = patch.start ?? undefined;
     if (patch.end !== undefined) jscal.end = patch.end ?? undefined;
     if (patch.description !== undefined) jscal.description = patch.description ?? undefined;
+    if (patch.location !== undefined)
+      jscal.locations = patch.location ? { l1: { name: patch.location } } : undefined;
+    if (patch.allDay !== undefined) jscal.showWithoutTime = patch.allDay ? true : undefined;
     if (patch.keywords !== undefined)
       jscal.keywords = patch.keywords?.length ? Object.fromEntries(patch.keywords.map((k) => [k, true])) : undefined;
     const etag = await etagOf(jscal);
@@ -438,7 +458,7 @@ export class SchedulingStore {
       ...(input.start ? { start: input.start } : {}),
       ...(input.due ? { due: input.due } : {}),
       ...(input.keywords?.length ? { keywords: Object.fromEntries(input.keywords.map((k) => [k, true])) } : {}),
-      ...(input.jscal ?? {}),
+      ...omit(input.jscal, TASK_MANAGED_KEYS),
     };
     const etag = await etagOf(jscal);
     await this.db.run(
@@ -460,9 +480,12 @@ export class SchedulingStore {
     return toTask(row);
   }
 
-  async listTasks(caller: Caller, opts: { spaceId?: string; calendars?: string[] } = {}): Promise<TaskRecord[]> {
-    const spaceIds = opts.spaceId ? [opts.spaceId] : await memberSpaceIds(this.db, caller.sub);
-    const out: TaskRecord[] = [];
+  async listTasks(
+    caller: Caller,
+    opts: { spaceId?: string; calendars?: string[] } = {},
+  ): Promise<(TaskRecord & { role: Role })[]> {
+    const spaceIds = await this.aggregateSpaceIds(caller, opts.spaceId);
+    const out: (TaskRecord & { role: Role })[] = [];
     for (const sid of spaceIds) {
       const rows = await this.db.all<TaskRow>(
         `SELECT * FROM tasks WHERE tenant_id = ? AND deleted_at IS NULL ORDER BY due`,
@@ -472,7 +495,7 @@ export class SchedulingStore {
         if (opts.calendars && !opts.calendars.includes(r.path)) continue;
         const role = await pathRole(this.db, r.tenant_id, r.path, caller.sub, caller.email ?? "");
         if (!role) continue;
-        out.push(toTask(r));
+        out.push({ ...toTask(r), role });
       }
     }
     return out;
@@ -488,7 +511,10 @@ export class SchedulingStore {
     if (patch.status !== undefined)
       jscal.progress = patch.status === "done" ? "completed" : patch.status === "in_progress" ? "in-process" : "needs-action";
     if (patch.progress !== undefined) jscal.percentComplete = patch.progress ?? undefined;
+    if (patch.start !== undefined) jscal.start = patch.start ?? undefined;
     if (patch.due !== undefined) jscal.due = patch.due ?? undefined;
+    if (patch.keywords !== undefined)
+      jscal.keywords = patch.keywords?.length ? Object.fromEntries(patch.keywords.map((k) => [k, true])) : undefined;
     const etag = await etagOf(jscal);
     await this.db.run(
       `UPDATE tasks SET title = ?, status = ?, progress = ?, start = ?, due = ?, priority = ?, keywords = ?, jscal = ?, etag = ?, updated_at = ?
@@ -547,6 +573,14 @@ export class SchedulingStore {
     );
     if (!ev) throw new Error("event not found");
     await this.requirePath(caller, ev.tenant_id, ev.path, "editor");
+    // The principal must belong to the event's space — otherwise listParticipants
+    // could surface a cross-tenant person's email/name.
+    const principal = await this.db.first<{ tenant_id: string | null }>(
+      `SELECT tenant_id FROM principals WHERE id = ?`,
+      [principalId],
+    );
+    if (!principal) throw new Error("principal not found");
+    if (principal.tenant_id !== ev.tenant_id) throw new PermissionError();
     await this.db.run(
       `INSERT INTO event_participants (event_id, principal_id, role, status) VALUES (?, ?, ?, ?)
          ON CONFLICT(event_id, principal_id) DO UPDATE SET role = excluded.role, status = excluded.status`,
@@ -573,4 +607,19 @@ export class SchedulingStore {
 /** Drop keys whose value is `undefined` so a partial patch doesn't clobber with undefined. */
 function stripUndefined<T extends object>(obj: T): Partial<T> {
   return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined)) as Partial<T>;
+}
+
+/**
+ * Keys the store manages itself in the canonical JSCalendar object (identity +
+ * indexed columns). User-supplied `input.jscal` must not override these, or the
+ * `jscal` payload would drift from the indexed columns. Anything else in
+ * `input.jscal` is kept as a user extension.
+ */
+const EVENT_MANAGED_KEYS = ["@type", "uid", "title", "start", "end", "showWithoutTime", "description", "locations", "keywords"];
+const TASK_MANAGED_KEYS = ["@type", "uid", "title", "progress", "percentComplete", "start", "due", "keywords"];
+
+function omit(obj: Record<string, unknown> | undefined, keys: string[]): Record<string, unknown> {
+  if (!obj) return {};
+  const drop = new Set(keys);
+  return Object.fromEntries(Object.entries(obj).filter(([k]) => !drop.has(k)));
 }

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -539,11 +539,12 @@ export const MIGRATIONS: { version: number; statements: string[] }[] = [
          owner_id    TEXT NOT NULL,
          uid         TEXT NOT NULL,
          title       TEXT NOT NULL,
-         status      TEXT NOT NULL DEFAULT 'todo', -- todo | in_progress | blocked | done
-         progress    INTEGER,                 -- JSCalendar percentComplete (0..100)
+         status      TEXT NOT NULL DEFAULT 'todo'
+                       CHECK (status IN ('todo', 'in_progress', 'blocked', 'done')),
+         progress    INTEGER CHECK (progress IS NULL OR (progress >= 0 AND progress <= 100)), -- JSCalendar percentComplete
          start       TEXT,
          due         TEXT,
-         priority    TEXT,                    -- low | normal | high
+         priority    TEXT CHECK (priority IS NULL OR priority IN ('low', 'normal', 'high')),
          keywords    TEXT,
          jscal       TEXT NOT NULL,
          etag        TEXT NOT NULL,
@@ -567,6 +568,10 @@ export const MIGRATIONS: { version: number; statements: string[] }[] = [
          created_at TEXT NOT NULL
        )`,
       `CREATE INDEX IF NOT EXISTS idx_principals_tenant ON principals (tenant_id)`,
+      // One person principal per (space, email) — matches upsertPrincipal's lookup so
+      // concurrent inserts can't mint duplicate ids for the same person.
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_principals_person
+         ON principals (tenant_id, email, kind) WHERE email IS NOT NULL AND kind = 'person'`,
       `CREATE TABLE IF NOT EXISTS event_participants (
          event_id     TEXT NOT NULL,
          principal_id TEXT NOT NULL,

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -489,6 +489,93 @@ export const MIGRATIONS: { version: number; statements: string[] }[] = [
        )`,
     ],
   },
+  {
+    // Scheduling (#34). Calendars, events, and tasks share the drive's identity
+    // and permission model: a "calendar" is just a virtual folder, so it reuses
+    // the `folders` table (here gained a display `name`, `color`, and `kind`) and
+    // the existing folder-grant ACL (`pathRole`/`requirePath`). Events and tasks
+    // live in their own tables (never `files`), so they never appear in drive
+    // listings; each carries `tenant_id` (the space) + `path` (the calendar folder)
+    // so a single folder grant covers a folder's documents *and* its scheduling
+    // items. JSCalendar (RFC 8984) is the canonical record shape — stored verbatim
+    // in `jscal` — with a few columns lifted out for indexed range/status queries.
+    // `principals` are identity hubs (people only for MVP); `event_participants`
+    // attaches them to events. No `space_seq` integration yet (offline mirror
+    // covers files only); scheduling items default to seq 0.
+    version: 23,
+    statements: [
+      // Calendars are folders. `kind`='calendar' marks a folder a user created as a
+      // calendar (so an empty calendar exists before its first event); NULL/'folder'
+      // is an ordinary virtual folder. `name`/`color` give it a display identity.
+      `ALTER TABLE folders ADD COLUMN name TEXT`,
+      `ALTER TABLE folders ADD COLUMN color TEXT`,
+      `ALTER TABLE folders ADD COLUMN kind TEXT`, // NULL | 'folder' | 'calendar'
+      `CREATE TABLE IF NOT EXISTS events (
+         id          TEXT PRIMARY KEY,
+         tenant_id   TEXT NOT NULL,           -- owning space id
+         path        TEXT NOT NULL DEFAULT '',-- calendar folder path ('' = space root)
+         owner_id    TEXT NOT NULL,
+         uid         TEXT NOT NULL,           -- JSCalendar logical identity (iCal UID)
+         title       TEXT NOT NULL,
+         start       TEXT,                    -- ISO 8601 (date or date-time)
+         end         TEXT,                    -- ISO 8601; NULL for point-in-time / all-day
+         all_day     INTEGER NOT NULL DEFAULT 0,
+         description TEXT,
+         location    TEXT,
+         keywords    TEXT,                    -- JSON array of tags (JSCalendar keywords)
+         jscal       TEXT NOT NULL,           -- full JSCalendar Event JSON
+         etag        TEXT NOT NULL,           -- content hash of jscal
+         seq         INTEGER NOT NULL DEFAULT 0,
+         created_at  TEXT NOT NULL,
+         updated_at  TEXT NOT NULL,
+         deleted_at  TEXT
+       )`,
+      `CREATE INDEX IF NOT EXISTS idx_events_tenant_start ON events (tenant_id, start)`,
+      `CREATE INDEX IF NOT EXISTS idx_events_tenant_path ON events (tenant_id, path)`,
+      `CREATE TABLE IF NOT EXISTS tasks (
+         id          TEXT PRIMARY KEY,
+         tenant_id   TEXT NOT NULL,
+         path        TEXT NOT NULL DEFAULT '',
+         owner_id    TEXT NOT NULL,
+         uid         TEXT NOT NULL,
+         title       TEXT NOT NULL,
+         status      TEXT NOT NULL DEFAULT 'todo', -- todo | in_progress | blocked | done
+         progress    INTEGER,                 -- JSCalendar percentComplete (0..100)
+         start       TEXT,
+         due         TEXT,
+         priority    TEXT,                    -- low | normal | high
+         keywords    TEXT,
+         jscal       TEXT NOT NULL,
+         etag        TEXT NOT NULL,
+         seq         INTEGER NOT NULL DEFAULT 0,
+         created_at  TEXT NOT NULL,
+         updated_at  TEXT NOT NULL,
+         deleted_at  TEXT
+       )`,
+      `CREATE INDEX IF NOT EXISTS idx_tasks_tenant_due ON tasks (tenant_id, due)`,
+      `CREATE INDEX IF NOT EXISTS idx_tasks_tenant_status ON tasks (tenant_id, status)`,
+      // Identity hubs. People only for MVP (kind='person'); orgs/resources later.
+      // `sub` links to a Canopy user when known; otherwise an external person is
+      // identified by email. Space-scoped (tenant_id) for MVP — global directory later.
+      `CREATE TABLE IF NOT EXISTS principals (
+         id         TEXT PRIMARY KEY,
+         tenant_id  TEXT,
+         kind       TEXT NOT NULL DEFAULT 'person',
+         sub        TEXT,
+         email      TEXT,
+         name       TEXT,
+         created_at TEXT NOT NULL
+       )`,
+      `CREATE INDEX IF NOT EXISTS idx_principals_tenant ON principals (tenant_id)`,
+      `CREATE TABLE IF NOT EXISTS event_participants (
+         event_id     TEXT NOT NULL,
+         principal_id TEXT NOT NULL,
+         role         TEXT,                   -- JSCalendar role: owner | attendee | ...
+         status       TEXT,                   -- needs-action | accepted | declined | tentative
+         PRIMARY KEY (event_id, principal_id)
+       )`,
+    ],
+  },
 ];
 
 /** Apply any migrations newer than what's recorded. Safe to call on every boot. */


### PR DESCRIPTION
Implements #34.

Adds user-owned scheduling (calendars, events, tasks) that **reuses the drive's identity and permission model** rather than inventing its own. A *calendar is a virtual folder* (`kind='calendar'` on the `folders` table), so sharing a calendar is a folder grant and every check routes through the existing `pathRole` ACL. Events and tasks live in their own tables (never `files`) and carry `space_id` + `path`, so one folder grant covers a folder's documents *and* its scheduling items. **JSCalendar (RFC 8984)** is the canonical storage shape, projected to the flat `CalendarEvent`/`Task` view shapes at the read boundary.

## What's included

- **store**: migration 23 (folders `name`/`color`/`kind`, `events`/`tasks`/`principals`/`event_participants`) + `SchedulingStore` (CRUD, folder-grant authz) + 9 tests
- **core**: `Calendar` type; `CalendarEvent`/`Task` gain calendar coordinates (`spaceId`/`path`/`calendarId`/`color`/`editable`)
- **api**: `SchedulingStore` wired into deps; `GET /api/calendar` & `/api/tasks` aggregate owned items with the GitHub provider and return the caller's calendars; `calendars`/`events` + owned `tasks` CRUD routes
- **spec**: `Calendar`/`Event`/`Principal` models + route interfaces; `openapi.yaml` regenerated
- **portal**: API client functions + capability bridge; **New calendar / New event** in the calendar plugin
- **docs**: calendar/tasks plugin pages + a "calendars are folders" section in Sharing & spaces

## Verification

- ✅ workspace typecheck (all 18 projects)
- ✅ 165 store tests pass (9 new), incl. permission reuse (non-members blocked, folder-share grants access, group members inherit)
- ✅ `tsp compile` clean, openapi regenerated
- ✅ portal build, calendar plugin JS parses

## Deferred (separate issues)

Recurrence, free/busy & availability, iCal/CalDAV/JMAP connectors, resource-principals, the generic Item/edge/provenance graph base.

## Follow-up

The aggregated calendar list + per-calendar colors are returned by the API and the plugin shows a grouped agenda with create forms; the full multi-calendar toggle sidebar (per-calendar checkboxes) is a reasonable next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added calendar, event, and task creation, editing, and removal.
  * Added calendar sharing and a new calendars list view.
  * Calendar and task views now support space-based filtering and show owned items alongside connected data.

* **Bug Fixes**
  * Improved calendar/task visibility so owned scheduling data appears reliably even when no external source is connected.
  * Updated calendar rendering to better reflect owned calendar colors and live data status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->