### PR TITLE
Welcome marketing plugin as the signed-out landing

### DIFF
--- a/POSITIONING.md
+++ b/POSITIONING.md
@@ -1,0 +1,144 @@
+# Canopy — Positioning
+
+> Internal reference for end-user marketing copy (the `welcome` plugin), the docs
+> intro, and any future messaging. Not a rendered docs page.
+
+## North star (the thesis)
+
+**Canopy is an operating system for your data and your life** — one place where your
+files live, your apps fit together, and your assistant always knows where everything
+is.
+
+It earns the "operating system" claim literally, not as a metaphor:
+
+| OS concept | Canopy |
+|---|---|
+| Kernel / shell | the slim core |
+| Filesystem | bring-your-own storage + the shared information model |
+| Apps | plugins |
+| System services every app gets free | the assistant, the data model, identity/auth |
+| Install / share apps | plugin sharing between users |
+| Programs that compose (Unix pipes) | apps that interoperate through the shared model |
+
+> Most tools *call* themselves an operating system. Canopy actually has a kernel, a
+> filesystem, and apps. Say it out loud — it's a real differentiator.
+
+## The four corollaries (everything reduces to the thesis)
+
+1. **No islands.** AI makes it trivial to spin up one-off apps, but they're islands —
+   their own data, disconnected from everything else. An OS is what turns apps into a
+   system. *(Files, calendar, tasks, notes — together, on shared ground.)*
+2. **It falls into place.** A shared filesystem means apps compose by default. Add one
+   thing and ten things just work — integrations you didn't plan for, just *there*.
+3. **Your assistant gets you.** The assistant is a system service reading one shared
+   model, so it has the right context for anything — taxes, vacation planning, your
+   training stats — with no per-app integration. *Every plugin you add doesn't just
+   work with your other apps; it teaches your assistant something new.*
+4. **No walls.** If you ever need more, it can exist in minutes — and what you build,
+   you can share. Extensibility is **headroom**, not homework: most people just use
+   what's there, but nothing is ever locked.
+
+## Target market
+
+The **platform is horizontal** — with the right plugins Canopy is equally a CRM, an ops
+tool, a team workspace. But the **landing page leads purely personal** (decided
+2026-06-28): warm, emotional, individual. No "business" or "CRM" language in the
+end-user copy. Rationale: personal is the authentic origin and the differentiator
+(SharePoint/Salesforce own "cold + corporate"; nobody owns "warm + personal + grows with
+you"), and personal→team is the proven land-and-expand path (Notion, Slack, Figma).
+Business capability stays implicit headroom, not a pitch. The "no walls" pillar uses
+personal examples only (workout log, reading list, budget, a game) — never CRM.
+
+## Positioning vs. the field
+
+|  | Fixed apps | Build-your-own apps |
+|---|---|---|
+| **Islands (siloed data)** | Google Workspace | v0 / Artifacts / Lovable / GPT apps |
+| **Shared data substrate** | micro.so | **Canopy** ← the empty corner |
+
+micro.so consolidated a *fixed* set of apps onto one substrate. The AI app-builders give
+*infinite* apps with *zero* shared data. Canopy is the only one claiming both: infinite
+apps, one substrate — and shareable.
+
+### The "build apps that integrate" precedents — who owns which corner
+
+| Who | Build real apps? | Apps share one data layer? | AI-native? | You own the data? | Personal? |
+|---|---|---|---|---|---|
+| Notion / Airtable | only inside their primitives | ✓ (locked to their model) | bolted on | ✗ | ✓ |
+| Salesforce / ServiceNow | ✓ | ✓ | partial | ✗ | ✗ |
+| SharePoint + Graph + Copilot | ✓ | ✓ | bolted on | ✗ | ✗ |
+| GPTs / Claude apps / v0 | ✓ | ✗ (islands) | ✓ | ✗ | ✓ |
+| Obsidian | ✓ (plugins) | ✓ (local notes) | ✗ | ✓ | ✓ |
+| **Canopy** | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+**SharePoint is the strongest precedent.** It handles all kinds of content (docs, lists,
+pages, media + metadata), sites ≈ spaces, lists ≈ the information model, web parts /
+Power Apps ≈ plugins — and it's the substrate *under the whole M365 suite* (Teams,
+OneDrive sit on it). Crucially, **Copilot works because of Microsoft Graph** — one
+unified model across all that content. So Microsoft already validated the entire thesis
+(shared substrate + assistant on top) — for enterprises. The pitch is therefore not
+"untested idea" but **proven model, new market**: Canopy is that, rebuilt personal,
+AI-native from the ground up, ownable, and consumer-simple.
+
+> **Defensible one-liner (investor/dev):** "What SharePoint + Copilot proved at
+> enterprise scale — rebuilt personal, AI-native, and ownable." / "Salesforce's
+> app-platform idea, for your own life."
+>
+> **Caveat:** never say "SharePoint" to end users — the word carries corporate-pain
+> baggage. End-user framing stays warm: "ChatGPT and Google Drive had a child you can
+> build apps on."
+
+### What we steal from micro.so
+- **Concreteness is the warmth.** Name the apps (files, calendar, tasks, notes), don't
+  say "unified workspace." Specificity reads as confidence.
+- **"and AI" as the tie that binds, not the buzzword up front.**
+- **Restraint** — one headline, little body copy, a little design personality.
+
+## Voice
+
+Warm + confident, not hypey. No superlatives we can't back up. Lead with the concrete
+*what*; let the "operating system" frame land last, as the name for something the reader
+has already understood.
+
+## Two surfaces, two voices
+
+- **Marketing** (the `welcome` plugin, signed-out landing): end-user, warm, leads with
+  the *why*. Owns the copy below.
+- **Docs** (the `documentation` plugin): builder-facing, factual, leads with the *how*.
+  Once `welcome` exists, pull landing-page duty off the docs plugin.
+
+## Hero copy (end-user marketing — current draft)
+
+> # Stop building islands.
+>
+> **Canopy is one place for your files, calendar, tasks, and notes — kept in storage
+> you own, with an assistant that can see across all of it.**
+>
+> Open it in your browser and it feels familiar: a drive, a calendar, a to-do list,
+> your documents. What's different is underneath — it's all one connected system. Ask
+> *"what did the Berlin trip cost?"* and your assistant pulls the dates from your
+> calendar and the receipts from your files, together, without you setting anything up.
+>
+> It doesn't stop at what's built in. Want a workout log, a reading list, a budget
+> tracker? Add one in minutes — or install one someone else made. Because everything
+> runs on the same system, whatever you add just works with the rest, and your
+> assistant understands it too.
+>
+> That's what makes Canopy an **operating system for your data and your life**: one
+> place where your files live, your apps fit together, and your assistant always knows
+> where everything is.
+
+### Page arc (for building out the landing below the hero)
+No islands → it compounds → your assistant actually understands your life → no ceiling.
+
+### Headlines in reserve
+- Promise-first (softer than the enemy frame): *"Build apps in minutes. They all fit together."*
+- OS-forward (developer / investor surface): *"An operating system for your data and your life. Not another app — the ground the apps stand on."*
+
+## Docs intro (builder-facing — factual)
+
+> Canopy is an extensible, AI-native portal. The first app is a **drive** over
+> bring-your-own storage (local filesystem, Cloudflare R2, or a connected source like a
+> NAS or GitHub repo). The same slim shell hosts first-party apps — calendar, tasks,
+> documentation — and sandboxed plugins right alongside them. This documentation covers
+> how it's built and how to extend it.

--- a/apps/portal/src/App.tsx
+++ b/apps/portal/src/App.tsx
@@ -75,7 +75,7 @@ import { CreateSpaceDialog } from "@/components/create-space-dialog";
 import { PluginSettingsDialog } from "@canopy/plugin-sdk";
 import { InviteGate } from "@/components/invite-gate";
 import { ConnectDeviceDialog } from "@/components/connect-device-dialog";
-import { createRegistry, ANON_DEFAULT_INSTALLED, DOCS_PLUGIN_ID, PLUGIN_UI } from "@/plugins";
+import { createRegistry, ANON_DEFAULT_INSTALLED, DOCS_PLUGIN_ID, WELCOME_PLUGIN_ID, PLUGIN_UI } from "@/plugins";
 import { HostApiProvider, type HostApi } from "@/plugins/host";
 import { createHostBridge } from "@/plugins/host-bridge";
 import { PluginHostProvider } from "@canopy/plugin-sdk";
@@ -313,18 +313,18 @@ function DesktopApp() {
     if (canPersist) saveInstalledPlugins(next).catch(() => {});
   }
 
-  // Documentation is the signed-out landing page — for anonymous-with-auth *and*
-  // demo (auth off) visitors. Applied once when auth first resolves; doesn't lock
-  // navigation afterwards. (Whether it's *installed* is server-driven — it ships
-  // only for anonymous/demo visitors.)
+  // Welcome (the marketing page) is the signed-out landing — for anonymous-with-auth
+  // *and* demo (auth off) visitors. Applied once when auth first resolves; doesn't
+  // lock navigation afterwards. (Whether it's *installed* is server-driven — it ships
+  // only for anonymous/demo visitors, alongside Documentation.)
   const initialHadView = useMemo(() => new URLSearchParams(window.location.search).has("view"), []);
-  const docsLandingApplied = useRef(false);
+  const landingApplied = useRef(false);
   useEffect(() => {
-    if (docsLandingApplied.current || !authLoaded) return;
-    docsLandingApplied.current = true;
+    if (landingApplied.current || !authLoaded) return;
+    landingApplied.current = true;
     if (!auth.user && !initialHadView) {
-      setActive(`plugin:${DOCS_PLUGIN_ID}`);
-      setActivePlugin(DOCS_PLUGIN_ID);
+      setActive(`plugin:${WELCOME_PLUGIN_ID}`);
+      setActivePlugin(WELCOME_PLUGIN_ID);
     }
   }, [authLoaded, auth, initialHadView]);
 

--- a/apps/portal/src/plugins/index.tsx
+++ b/apps/portal/src/plugins/index.tsx
@@ -5,6 +5,7 @@ import { TasksView } from "./detail-views";
 import { GithubView } from "./github-view";
 import { SynologyView } from "./synology-view";
 import { DocumentAiView } from "./document-ai-view";
+import { WelcomeView } from "./welcome-view";
 
 // Lazy-loaded: pulls react-markdown + remark-gfm into a separate chunk.
 const DocumentationView = lazy(() => import("./documentation-view").then((m) => ({ default: m.DocumentationView })));
@@ -51,6 +52,7 @@ export interface PluginUI {
 }
 
 export const PLUGIN_UI: Record<string, PluginUI> = {
+  welcome: { DetailView: WelcomeView },
   documentation: { DetailView: DocumentationView },
   tasks: { DetailView: TasksView },
   github: { DetailView: GithubView },
@@ -77,4 +79,4 @@ export function createRegistry(installedIds: string[], customManifests: PluginMa
   return registry;
 }
 
-export { DEFAULT_INSTALLED, ANON_DEFAULT_INSTALLED, DOCS_PLUGIN_ID } from "./manifests";
+export { DEFAULT_INSTALLED, ANON_DEFAULT_INSTALLED, DOCS_PLUGIN_ID, WELCOME_PLUGIN_ID } from "./manifests";

--- a/apps/portal/src/plugins/manifests.ts
+++ b/apps/portal/src/plugins/manifests.ts
@@ -48,6 +48,7 @@ const CAPABILITY_OVERRIDES: Record<string, PluginManifest["capabilities"]> = {
 export function buildManifest(id: string): PluginManifest | undefined {
   const bundled = BUNDLED_MANIFEST_BY_ID.get(id);
   if (bundled) return bundled;
+  if (id === WELCOME_PLUGIN_ID) return WELCOME_MANIFEST;
   const cat = PLUGIN_CATALOG.find((c) => c.id === id);
   if (!cat) return undefined;
   return {
@@ -67,6 +68,27 @@ export function buildManifest(id: string): PluginManifest | undefined {
 export const DOCS_PLUGIN_ID = "documentation";
 
 /**
+ * The Welcome / marketing landing — the signed-out experience. Not an installable
+ * store app (deliberately absent from PLUGIN_CATALOG), so its manifest is authored
+ * here and returned directly from buildManifest. Renders immersive (edge-to-edge,
+ * no plugin header) and contributes no nav entry — it's reached via the signed-out
+ * landing redirect (see App.tsx) and `?view=plugin:welcome`.
+ */
+export const WELCOME_PLUGIN_ID = "welcome";
+
+const WELCOME_MANIFEST: PluginManifest = {
+  id: WELCOME_PLUGIN_ID,
+  name: "Welcome",
+  version: "0.1.0",
+  icon: "home",
+  color: "145 33% 36%", // Canopy green
+  capabilities: [], // static marketing page — reads nothing from the host
+  contributes: {
+    detailView: { id: "welcome-detail", title: "Welcome", immersive: true },
+  },
+};
+
+/**
  * Plugins installed by default for signed-in users. Includes the baseline file
  * viewers (image/pdf/markdown) so common file types preview out of the box;
  * other viewers (code, univer) are installed from the store on demand.
@@ -81,7 +103,8 @@ export const DEFAULT_INSTALLED = [
 ];
 
 /**
- * Signed-out / anonymous visitors also get Documentation, which doubles as the
- * landing experience. Signed-in users install it from the store if they want it.
+ * Signed-out / anonymous visitors land on Welcome (the marketing page) and also
+ * get Documentation so they can browse the guides. Signed-in users get neither by
+ * default (Welcome isn't installable; Documentation installs from the store).
  */
-export const ANON_DEFAULT_INSTALLED = [DOCS_PLUGIN_ID, ...DEFAULT_INSTALLED];
+export const ANON_DEFAULT_INSTALLED = [WELCOME_PLUGIN_ID, DOCS_PLUGIN_ID, ...DEFAULT_INSTALLED];

--- a/apps/portal/src/plugins/welcome-view.tsx
+++ b/apps/portal/src/plugins/welcome-view.tsx
@@ -1,0 +1,193 @@
+import { Button } from "@/components/ui/button";
+import { cn, Icon } from "@canopy/ui";
+import { loginUrl } from "@/lib/api";
+
+/**
+ * Welcome / marketing landing — the signed-out experience. A purely personal,
+ * end-user pitch (no "business"/"CRM" language; the platform stays horizontal
+ * underneath). Copy and structure track the canonical positioning in the repo's
+ * POSITIONING.md: the arc is no islands → it falls into place → your assistant
+ * gets you → no walls, with the "operating system for your data and your life"
+ * reveal landing last. Rendered immersive (edge-to-edge, no plugin header) via the
+ * manifest's detailView.immersive flag.
+ */
+
+// Start sign-in like the host does (App.signIn), but return to the app root rather
+// than back here — `?view=plugin:welcome` isn't installed for signed-in users, so
+// returning to it would land them on a blank view. Dropping the query sends them to
+// their drive instead.
+function startSignIn() {
+  window.location.href = loginUrl(window.location.pathname);
+}
+
+/** The built-in apps, named (concreteness is the warmth — see POSITIONING.md). */
+const APPS: { icon: string; label: string }[] = [
+  { icon: "my-drive", label: "Files" },
+  { icon: "calendar", label: "Calendar" },
+  { icon: "check-square", label: "Tasks" },
+  { icon: "file-text", label: "Notes" },
+  { icon: "sparkles", label: "Assistant" },
+];
+
+/** The four corollaries of the thesis, in arc order. */
+const PILLARS: { icon: string; title: string; body: string }[] = [
+  {
+    icon: "grid",
+    title: "No more islands",
+    body: "AI makes it easy to spin up a clever one-off app — and end up with a drawer of things that don't talk to each other. Canopy puts everything on shared ground, so it's one system, not a pile of silos.",
+  },
+  {
+    icon: "plugin",
+    title: "It falls into place",
+    body: "Because it all shares one data layer, your apps fit together by default. Add one thing and ten things just work — integrations you never planned for, simply there.",
+  },
+  {
+    icon: "sparkles",
+    title: "Your assistant gets you",
+    body: "The assistant reads the same shared model everything else does, so it has the right context for whatever you're doing — your calendar, your files, your numbers — with nothing to set up.",
+  },
+  {
+    icon: "package",
+    title: "No walls",
+    body: "You'll probably just use what's here. But nothing's ever locked: if you need something new, it can exist in minutes — and what you build, you can share.",
+  },
+];
+
+/** Concrete, personal examples of the headroom — never business/CRM (see POSITIONING.md). */
+const EXAMPLES: { icon: string; label: string }[] = [
+  { icon: "timer", label: "Workout log" },
+  { icon: "bookmark", label: "Reading list" },
+  { icon: "wallet", label: "Budget tracker" },
+  { icon: "gamepad-2", label: "A little game" },
+];
+
+function IconTile({ name, className }: { name: string; className?: string }) {
+  return (
+    <div className={cn("grid size-11 shrink-0 place-items-center rounded-xl bg-primary/10 text-primary", className)}>
+      <Icon name={name} size={22} />
+    </div>
+  );
+}
+
+export function WelcomeView() {
+  return (
+    <div className="min-h-full bg-background">
+      {/* ── Hero ─────────────────────────────────────────────────────────── */}
+      <section className="relative overflow-hidden border-b border-border/60">
+        {/* soft Canopy-green wash behind the hero */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 bg-gradient-to-b from-primary/[0.07] to-transparent"
+        />
+        <div className="relative mx-auto max-w-[820px] px-6 py-20 text-center sm:py-28">
+          <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/60 px-3 py-1 text-[12px] font-medium text-muted-foreground">
+            <span className="size-1.5 rounded-full bg-primary" />
+            Your stuff · your home · your assistant
+          </div>
+
+          <h1 className="text-balance text-[44px] font-semibold leading-[1.05] tracking-tight sm:text-[56px]">
+            Stop building islands.
+          </h1>
+
+          <p className="mx-auto mt-6 max-w-[640px] text-balance text-[18px] font-medium leading-relaxed text-foreground/90">
+            Canopy is one place for your files, calendar, tasks, and notes — kept in storage you own, with an
+            assistant that can see across all of it.
+          </p>
+
+          <p className="mx-auto mt-4 max-w-[600px] text-[15px] leading-relaxed text-muted-foreground">
+            Open it in your browser and it feels familiar: a drive, a calendar, a to-do list. What's different is
+            underneath — it's all one connected system. Ask{" "}
+            <span className="font-medium text-foreground">"what did the Berlin trip cost?"</span> and your assistant
+            pulls the dates from your calendar and the receipts from your files, together, without you setting
+            anything up.
+          </p>
+
+          {/* the apps, named */}
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-2">
+            {APPS.map((a) => (
+              <span
+                key={a.label}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-background px-3 py-1.5 text-[13px] font-medium text-foreground/80"
+              >
+                <Icon name={a.icon} size={14} className="text-primary" />
+                {a.label}
+              </span>
+            ))}
+          </div>
+
+          <div className="mt-9 flex flex-wrap items-center justify-center gap-3">
+            <Button size="lg" className="gap-1.5 px-6" onClick={startSignIn}>
+              Get started
+              <Icon name="chevron-right" size={16} />
+            </Button>
+            <Button asChild size="lg" variant="outline" className="px-6">
+              <a href="?view=plugin:documentation">Explore the docs</a>
+            </Button>
+          </div>
+
+          <p className="mt-7 text-[13px] italic text-muted-foreground">
+            What if ChatGPT and Google Drive had a child — one you could build apps on?
+          </p>
+        </div>
+      </section>
+
+      {/* ── The four corollaries ─────────────────────────────────────────── */}
+      <section className="mx-auto max-w-[940px] px-6 py-16 sm:py-20">
+        <div className="grid gap-5 sm:grid-cols-2">
+          {PILLARS.map((p) => (
+            <div
+              key={p.title}
+              className="flex flex-col gap-4 rounded-2xl border border-border/70 bg-card p-6 transition-colors hover:border-primary/40"
+            >
+              <IconTile name={p.icon} />
+              <div>
+                <h2 className="text-[18px] font-semibold tracking-tight">{p.title}</h2>
+                <p className="mt-1.5 text-[14.5px] leading-relaxed text-muted-foreground">{p.body}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* headroom made concrete */}
+        <div className="mt-5 rounded-2xl border border-dashed border-border/70 bg-muted/30 p-6">
+          <p className="text-[14px] font-medium text-foreground/80">
+            Build it in minutes, or install one someone else made — and it works with everything from day one:
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2.5">
+            {EXAMPLES.map((e) => (
+              <span
+                key={e.label}
+                className="inline-flex items-center gap-2 rounded-lg border border-border/70 bg-background px-3 py-2 text-[13.5px] font-medium text-foreground/80"
+              >
+                <Icon name={e.icon} size={15} className="text-primary" />
+                {e.label}
+              </span>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── The reveal + closing CTA ─────────────────────────────────────── */}
+      <section className="border-t border-border/60 bg-primary/[0.04]">
+        <div className="mx-auto max-w-[720px] px-6 py-20 text-center">
+          <h2 className="text-balance text-[30px] font-semibold leading-tight tracking-tight sm:text-[36px]">
+            An operating system for your data and your life.
+          </h2>
+          <p className="mx-auto mt-4 max-w-[560px] text-[16px] leading-relaxed text-muted-foreground">
+            One place where your files live, your apps fit together, and your assistant always knows where everything
+            is. Yours to keep, yours to shape.
+          </p>
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+            <Button size="lg" className="gap-1.5 px-6" onClick={startSignIn}>
+              Get started
+              <Icon name="chevron-right" size={16} />
+            </Button>
+            <Button asChild size="lg" variant="outline" className="px-6">
+              <a href="?view=plugin:documentation">See how it works</a>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
Splits the signed-out landing page off from Documentation. Anonymous and demo visitors now land on **Welcome** — an immersive, end-user marketing page — instead of the docs, which stay installed so they can still browse the guides.

### What's here
- **`POSITIONING.md`** — the canonical positioning the copy tracks, so the page and future marketing surfaces don't drift. North star is *"an operating system for your data and your life"*, reached via four corollaries (no islands → it falls into place → your assistant gets you → no walls), plus voice and the end-user vs. builder surface split.
- **`welcome-view.tsx`** — the page itself: hero → the four corollaries → concrete headroom examples → the reveal. Static; declares no capabilities and reads nothing from the host.
- **Wiring** — Welcome is deliberately *not* in `PLUGIN_CATALOG`: it isn't an installable store app, so its manifest is authored in `manifests.ts` and returned directly from `buildManifest`. It renders immersive (edge-to-edge, no plugin header), contributes no nav entry, and is reached via the signed-out landing redirect and `?view=plugin:welcome`.

### Notes
- Signed-in users get neither by default — Welcome isn't installable, Documentation installs from the store.
- Sign-in returns to the app root rather than back to `?view=plugin:welcome`, which isn't installed for signed-in users and would land them on a blank view.

### Validation
Portal typecheck clean. Lint is unchanged from the `main` baseline (already red there — 35 pre-existing errors, none in these files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)