### PR TITLE
fix(portal): in-app modal for New folder (and every other name prompt)

### DIFF
--- a/apps/portal/src/App.tsx
+++ b/apps/portal/src/App.tsx
@@ -72,6 +72,7 @@ import { SpaceMembersDialog } from "@/components/space-members-dialog";
 import { SpaceCacheDialog } from "@/components/space-cache-dialog";
 import { ConnectorSettingsDialog } from "@/components/connector-settings-dialog";
 import { CreateSpaceDialog } from "@/components/create-space-dialog";
+import { NameDialog, type NamePrompt } from "@/components/name-dialog";
 import { PluginSettingsDialog } from "@canopy/plugin-sdk";
 import { InviteGate } from "@/components/invite-gate";
 import { ConnectDeviceDialog } from "@/components/connect-device-dialog";
@@ -366,6 +367,8 @@ function DesktopApp() {
   const [connectorSettings, setConnectorSettings] = useState<{ pluginId: string; name: string } | null>(null);
   const [createSpaceOpen, setCreateSpaceOpen] = useState(false);
   const [connectOpen, setConnectOpen] = useState(false);
+  // The single-name modal currently asked of the user (new folder, renames, new file), or null.
+  const [namePrompt, setNamePrompt] = useState<NamePrompt | null>(null);
   const [overview, setOverview] = useState<Overview>({ files: 0, bytes: 0 });
   const [sharedCount, setSharedCount] = useState(0);
   const [dragOver, setDragOver] = useState(false);
@@ -601,20 +604,22 @@ function DesktopApp() {
     setCreateSpaceOpen(true);
   }
 
-  async function renameSpaceFlow(id: string) {
+  function renameSpaceFlow(id: string) {
     const current = spaces.find((s) => s.id === id);
-    const name = window.prompt("Rename space", current?.name ?? "");
-    if (!name?.trim() || name.trim() === current?.name) return;
-    try {
-      await renameSpace(id, name.trim());
-      setSpaces(await listSpaces());
-      toast(`Renamed to “${name.trim()}”`);
-    } catch (err) {
-      toast("Couldn't rename space", { description: (err as Error).message });
-    }
+    setNamePrompt({
+      title: "Rename space",
+      initial: current?.name ?? "",
+      submitLabel: "Rename",
+      onSubmit: async (name) => {
+        if (name === current?.name) return;
+        await renameSpace(id, name);
+        setSpaces(await listSpaces());
+        toast(`Renamed to “${name}”`);
+      },
+    });
   }
 
-  async function createFolderFlow() {
+  function createFolderFlow() {
     if (!online) {
       toast("You're offline", { description: "You can't create folders until you're back online." });
       return;
@@ -627,18 +632,19 @@ function DesktopApp() {
       toast("This space is read-only");
       return;
     }
-    const name = window.prompt("Folder name");
-    if (!name?.trim()) return;
-    try {
-      await createFolder([path, name.trim()].filter(Boolean).join("/"), space || undefined);
-      reload();
-      toast(`Created “${name.trim()}”`);
-    } catch (err) {
-      toast("Couldn't create folder", { description: (err as Error).message });
-    }
+    setNamePrompt({
+      title: "New folder",
+      placeholder: "Folder name",
+      submitLabel: "Create",
+      onSubmit: async (name) => {
+        await createFolder([path, name].filter(Boolean).join("/"), space || undefined);
+        reload();
+        toast(`Created “${name}”`);
+      },
+    });
   }
 
-  async function createFileFlow(creator: InstalledCreator) {
+  function createFileFlow(creator: InstalledCreator) {
     if (!online) {
       toast("You're offline", { description: "You can't create files until you're back online." });
       return;
@@ -651,17 +657,18 @@ function DesktopApp() {
       toast("This space is read-only");
       return;
     }
-    const input = window.prompt(`${creator.label} name`, creator.defaultName);
-    if (!input?.trim()) return;
-    const base = input.trim();
-    const name = base.toLowerCase().endsWith(creator.extension) ? base : base + creator.extension;
-    try {
-      const file = await createFile(path, name, creator.template ?? "", creator.mime, space || undefined);
-      reload();
-      setPreviewFile(file); // open straight in the matching viewer/editor
-    } catch (err) {
-      toast("Couldn't create file", { description: (err as Error).message });
-    }
+    setNamePrompt({
+      title: `New ${creator.label.toLowerCase()}`,
+      placeholder: `${creator.label} name`,
+      initial: creator.defaultName,
+      submitLabel: "Create",
+      onSubmit: async (base) => {
+        const name = base.toLowerCase().endsWith(creator.extension) ? base : base + creator.extension;
+        const file = await createFile(path, name, creator.template ?? "", creator.mime, space || undefined);
+        reload();
+        setPreviewFile(file); // open straight in the matching viewer/editor
+      },
+    });
   }
 
   // Generic host bridge handed to trusted, first-party plugin UI (the Model Editor
@@ -884,18 +891,23 @@ function DesktopApp() {
         toast("Folders can't be renamed yet");
         return;
       }
-      const name = window.prompt("Rename file", f.name);
-      if (!name?.trim() || name.trim() === f.name) return;
-      const next = name.trim();
-      setFiles((fs) => fs.map((x) => (x.id === f.id ? { ...x, name: next } : x))); // optimistic
-      try {
-        await renameFile(f.id, next);
-        reload();
-        toast(`Renamed to “${next}”`);
-      } catch (err) {
-        reload(); // rollback to server truth
-        toast("Couldn't rename", { description: (err as Error).message });
-      }
+      setNamePrompt({
+        title: "Rename file",
+        initial: f.name,
+        submitLabel: "Rename",
+        onSubmit: async (next) => {
+          if (next === f.name) return;
+          setFiles((fs) => fs.map((x) => (x.id === f.id ? { ...x, name: next } : x))); // optimistic
+          try {
+            await renameFile(f.id, next);
+            reload();
+            toast(`Renamed to “${next}”`);
+          } catch (err) {
+            reload(); // rollback to server truth
+            throw err; // surfaces inline in the dialog
+          }
+        },
+      });
     } else if (action === "Reprocess") {
       if (f.kind === "folder") return; // folders have no content to process
       try {
@@ -1376,6 +1388,10 @@ function DesktopApp() {
           open={!!shareTarget}
           onOpenChange={(o) => !o && setShareTarget(null)}
         />
+      )}
+
+      {namePrompt && (
+        <NameDialog prompt={namePrompt} onOpenChange={(o) => !o && setNamePrompt(null)} />
       )}
 
       {createSpaceOpen && (

--- a/apps/portal/src/components/name-dialog.tsx
+++ b/apps/portal/src/components/name-dialog.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+/**
+ * What a single-name ask looks like. Hosts keep one `NamePrompt | null` in
+ * state and render a `NameDialog` from it — the in-app replacement for
+ * `window.prompt` (new folder, renames, new file), so every name flow shares
+ * one styled modal instead of a native browser dialog.
+ */
+export interface NamePrompt {
+  title: string;
+  description?: string;
+  placeholder?: string;
+  /** Prefilled value (selected on focus, like the native prompt was). */
+  initial?: string;
+  submitLabel?: string;
+  /** Throwing keeps the dialog open with the message shown inline. */
+  onSubmit: (name: string) => void | Promise<void>;
+}
+
+export function NameDialog({
+  prompt,
+  onOpenChange,
+}: {
+  prompt: NamePrompt;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [value, setValue] = useState(prompt.initial ?? "");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const name = value.trim();
+    if (!name || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await prompt.onSubmit(name);
+      onOpenChange(false);
+    } catch (err) {
+      setError((err as Error).message);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => !busy && onOpenChange(o)}>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>{prompt.title}</DialogTitle>
+          {prompt.description && <DialogDescription>{prompt.description}</DialogDescription>}
+        </DialogHeader>
+        <form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col gap-3">
+          <Input
+            autoFocus
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+              setError(null);
+            }}
+            onFocus={(e) => e.currentTarget.select()}
+            placeholder={prompt.placeholder}
+            disabled={busy}
+          />
+          {error && <p className="text-[12.5px] text-destructive">{error}</p>}
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={busy || !value.trim()}>
+              {busy ? "Working…" : (prompt.submitLabel ?? "Save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/portal/src/mobile/mobile-app.tsx
+++ b/apps/portal/src/mobile/mobile-app.tsx
@@ -22,6 +22,7 @@ import { DemoBanner } from "@/components/demo-banner";
 import { InviteBanner } from "@/components/invite-banner";
 import { OfflineBanner } from "@/components/offline-banner";
 import { PullToRefresh } from "@/components/pull-to-refresh";
+import { NameDialog, type NamePrompt } from "@/components/name-dialog";
 import { HomeScreen, DriveScreen, SpacesScreen, AppsScreen } from "./screens";
 import { NewActionSheet, FileDetailSheet } from "./sheets";
 
@@ -43,6 +44,8 @@ export function MobileApp() {
   const [installed, setInstalled] = useState<string[]>(ANON_DEFAULT_INSTALLED);
   // Bumped on pull-to-refresh; screens fold it into their fetch deps to reload.
   const [refreshKey, setRefreshKey] = useState(0);
+  // The single-name modal currently asked of the user (new note), or null.
+  const [namePrompt, setNamePrompt] = useState<NamePrompt | null>(null);
   const uploadRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -101,19 +104,20 @@ export function MobileApp() {
     setRefreshKey((k) => k + 1);
   };
 
-  async function createNote() {
+  function createNote() {
     const creator = CREATORS.find((c) => c.extension === ".md");
     if (!creator) return;
-    const input = window.prompt(`${creator.label} name`, creator.defaultName);
-    if (!input?.trim()) return;
-    const base = input.trim();
-    const name = base.toLowerCase().endsWith(creator.extension) ? base : base + creator.extension;
-    try {
-      const file = await createFile("", name, creator.template ?? "", creator.mime);
-      openFile(file); // opens in the detail sheet, which mounts the markdown editor
-    } catch (e) {
-      toast("Couldn't create note", { description: (e as Error).message });
-    }
+    setNamePrompt({
+      title: `New ${creator.label.toLowerCase()}`,
+      placeholder: `${creator.label} name`,
+      initial: creator.defaultName,
+      submitLabel: "Create",
+      onSubmit: async (base) => {
+        const name = base.toLowerCase().endsWith(creator.extension) ? base : base + creator.extension;
+        const file = await createFile("", name, creator.template ?? "", creator.mime);
+        openFile(file); // opens in the detail sheet, which mounts the markdown editor
+      },
+    });
   }
 
   async function doUpload(list: FileList | null) {
@@ -203,6 +207,10 @@ export function MobileApp() {
         onNewNote={createNote}
       />
       <FileDetailSheet file={selFile} open={sheet === "file"} onOpenChange={(o) => setSheet(o ? "file" : null)} installedPluginIds={installed} />
+
+      {namePrompt && (
+        <NameDialog prompt={namePrompt} onOpenChange={(o) => !o && setNamePrompt(null)} />
+      )}
 
       <input
         ref={uploadRef}


### PR DESCRIPTION
Fixes #2.

The "New folder" action (and the other single-name asks that shared the same pattern) used a native `window.prompt`. This adds a small reusable `NameDialog` (shadcn Dialog + Input) and swaps all five call sites onto it:

- **New folder** (the issue)
- Rename space
- Rename file
- New file from an installed creator (desktop)
- New note (mobile shell)

Behavior notes:
- The prefilled value is selected on focus, matching how the native prompt behaved for renames.
- Errors now surface inline in the dialog and keep it open (previously the prompt was already gone, so failures could only toast). The rename-file optimistic update still rolls back via `reload()` before re-throwing.
- Empty/unchanged names are no-ops, as before.

## Verification
- ✅ `pnpm typecheck` (portal)
- ✅ `pnpm build` (portal, incl. PWA precache)
- ✅ `grep window.prompt` → no call sites left (one doc comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent naming dialog for creating and renaming spaces, folders, files, and notes.
  * Dialogs support placeholders, initial names, custom submit labels, loading states, and inline error messages.
  * Newly created files and notes open automatically after creation.

* **Bug Fixes**
  * File rename failures now restore the previous filename while displaying the error in the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->