### PR TITLE
feat(store): generalize index_runs into a runs table (jobs rail T1)

### DIFF
--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -177,7 +177,7 @@ export async function buildDeps(env: WorkerEnv, waitUntil?: (p: Promise<unknown>
   // the `/logs/stream` endpoint subscribes to (the real connector space id), so the
   // workflow's lines reach the open dialog. Awaitable + best-effort: the workflow calls
   // it inside a `step.do` so a line fires when the step runs, not on cache-replay.
-  const indexLog: IndexLog = channel
+  const indexLog: RunLog = channel
     ? async (spaceId, message, level = "info") => {
         try {
           await channel
@@ -200,8 +200,10 @@ export async function buildDeps(env: WorkerEnv, waitUntil?: (p: Promise<unknown>
   return { db, blobs, search, authConfig, plugins, connectorFor, connectorForUser, service, indexLog };
 }
 
-/** Emit one indexing progress line to a space's live channel. Best-effort, never throws. */
-export type IndexLog = (spaceId: string, message: string, level?: "info" | "error") => Promise<void>;
+/** Emit one run progress line to a space's live channel. Best-effort, never throws. */
+export type RunLog = (spaceId: string, message: string, level?: "info" | "error") => Promise<void>;
+/** @deprecated Renamed to {@link RunLog} (jobs rail, T1); alias goes away with the bespoke index path (T6). */
+export type IndexLog = RunLog;
 
 /**
  * The Cloudflare {@link IndexJobs} impl: a durable Workflow runs the connector crawl

--- a/packages/store/src/connections.ts
+++ b/packages/store/src/connections.ts
@@ -1,4 +1,5 @@
 import type { Db } from "./db";
+import { failRun, finishRun, startRun } from "./runs";
 import type { Connection } from "./types";
 
 /**
@@ -60,38 +61,28 @@ export async function listAllConnections(db: Db): Promise<Connection[]> {
 }
 
 // ── index runs (resumable crawl bookkeeping) ─────────────────────────────────
-// Each sweep of a connection is an `index_runs` row. The `cursor` carries the
+// Each sweep of a connection is a `runs` row (jobs rail, T1) keyed
+// (connection type, 'connector-index', connection id). The `cursor` carries the
 // high-water change marker (for Synology: the last seen mtime, unix seconds) from
 // the most recent successful run to the next, so an incremental sweep only revisits
-// what changed since.
+// what changed since. These three are thin compatibility wrappers over runs.ts so
+// existing callers compile unchanged; they go away when connector indexing moves
+// onto the generic rail (T6).
 
 /** Start a sweep: record a 'running' run seeded with the last successful cursor. Returns the run id + that cursor. */
 export async function startIndexRun(db: Db, connectionId: string): Promise<{ id: string; cursor: string | null }> {
-  const last = await db.first<{ cursor: string | null }>(
-    "SELECT cursor FROM index_runs WHERE connection_id = ? AND status = 'done' ORDER BY finished_at DESC LIMIT 1",
-    [connectionId],
-  );
-  const id = crypto.randomUUID();
-  await db.run(
-    "INSERT INTO index_runs (id, connection_id, status, cursor, files_seen, started_at) VALUES (?, ?, 'running', ?, 0, ?)",
-    [id, connectionId, last?.cursor ?? null, new Date().toISOString()],
-  );
-  return { id, cursor: last?.cursor ?? null };
+  // plugin_id = the connection's type; '' when the row is gone, matching how the
+  // migration copied orphaned index_runs rows, so their cursor still resolves.
+  const conn = await getConnection(db, connectionId);
+  return startRun(db, { pluginId: conn?.type ?? "", jobName: "connector-index", instanceKey: connectionId });
 }
 
 /** Mark a run done, persisting its new cursor + count. */
 export async function finishIndexRun(db: Db, runId: string, out: { cursor: string | null; filesSeen: number }): Promise<void> {
-  await db.run(
-    "UPDATE index_runs SET status = 'done', cursor = ?, files_seen = ?, finished_at = ? WHERE id = ?",
-    [out.cursor, out.filesSeen, new Date().toISOString(), runId],
-  );
+  await finishRun(db, runId, { cursor: out.cursor, stats: { filesSeen: out.filesSeen } });
 }
 
 /** Mark a run failed (its cursor is not advanced, so the next run retries the same range). */
 export async function failIndexRun(db: Db, runId: string, error: string): Promise<void> {
-  await db.run("UPDATE index_runs SET status = 'error', error = ?, finished_at = ? WHERE id = ?", [
-    String(error ?? "").slice(0, 500),
-    new Date().toISOString(),
-    runId,
-  ]);
+  await failRun(db, runId, error);
 }

--- a/packages/store/src/connector-sync.test.ts
+++ b/packages/store/src/connector-sync.test.ts
@@ -289,8 +289,8 @@ describe("sweep (syncConnection)", () => {
     nas.set("new.md", "fresh", { mtime: 2000 }); // changed since the cursor below
     // Seed a prior successful run so syncConnection takes the incremental path.
     await db.run(
-      "INSERT INTO index_runs (id, connection_id, status, cursor, files_seen, started_at, finished_at) VALUES ('r0', ?, 'done', '1500', 0, ?, ?)",
-      [space, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z"],
+      "INSERT INTO runs (id, plugin_id, job_name, instance_key, status, cursor, stats, started_at, finished_at) VALUES ('r0', ?, 'connector-index', ?, 'done', '1500', '{}', ?, ?)",
+      [PLUGIN, space, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z"],
     );
     await syncConnection(deps(true), conn());
     // Root was reconciled (it held a changed file) → both root files indexed...
@@ -303,7 +303,7 @@ describe("sweep (syncConnection)", () => {
     nas.set("a.md", "x");
     await syncConnection(deps(true), conn());
     const run = await db.first<{ cursor: string | null; status: string }>(
-      "SELECT cursor, status FROM index_runs WHERE connection_id = ? ORDER BY finished_at DESC LIMIT 1",
+      "SELECT cursor, status FROM runs WHERE job_name = 'connector-index' AND instance_key = ? ORDER BY finished_at DESC LIMIT 1",
       [space],
     );
     expect(run?.status).toBe("done");

--- a/packages/store/src/files.ts
+++ b/packages/store/src/files.ts
@@ -2265,7 +2265,7 @@ export class FileService {
   ): Promise<{ indexing: boolean; pending: number; lastIndexedAt: string | null }> {
     const spaceId = connectorSpaceId(userSub, pluginId);
     const running = await this.db.first<{ id: string }>(
-      "SELECT id FROM index_runs WHERE connection_id = ? AND status = 'running' LIMIT 1",
+      "SELECT id FROM runs WHERE job_name = 'connector-index' AND instance_key = ? AND status = 'running' LIMIT 1",
       [spaceId],
     );
     const pendingRow = await this.db.first<{ n: number }>(
@@ -2274,7 +2274,7 @@ export class FileService {
       [spaceId],
     );
     const last = await this.db.first<{ finished_at: string | null }>(
-      "SELECT finished_at FROM index_runs WHERE connection_id = ? AND status = 'done' ORDER BY finished_at DESC LIMIT 1",
+      "SELECT finished_at FROM runs WHERE job_name = 'connector-index' AND instance_key = ? AND status = 'done' ORDER BY finished_at DESC LIMIT 1",
       [spaceId],
     );
     const pending = pendingRow?.n ?? 0;

--- a/packages/store/src/index-jobs-local.ts
+++ b/packages/store/src/index-jobs-local.ts
@@ -11,7 +11,7 @@ import type { IndexJobs } from "./index-jobs";
  * Unlike the bounded safety-net sweep ({@link import("./connector-sync").syncConnection}),
  * this does a FULL crawl — Node isn't subrequest/CPU-constrained, so we index the whole
  * tree in one pass — then drains extraction in batches until the pending queue is empty.
- * It records progress as an `index_runs` row, exactly like the sweep, so the two share
+ * It records progress as a `runs` row, exactly like the sweep, so the two share
  * the cursor and re-runs stay idempotent (reconcile is an etag diff).
  */
 export function inProcessIndexJobs(deps: SweepDeps): IndexJobs {

--- a/packages/store/src/index-jobs.ts
+++ b/packages/store/src/index-jobs.ts
@@ -16,7 +16,7 @@ export interface IndexJobs {
    * Index a whole connector: crawl its tree, upserting external file rows into the DB,
    * and drain text extraction. Idempotent per target — a second call for an in-flight
    * target coalesces (the CF Workflow keys its instance by `spaceId`; the in-process
-   * runner dedups via the `index_runs` cursor). The caller backgrounds this
+   * runner dedups via the `runs` cursor). The caller backgrounds this
    * (`waitUntil` on a Worker, fire-and-forget on Node) — it never blocks a response.
    */
   startConnectorIndex(target: CrawlTarget): Promise<void>;

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -15,6 +15,7 @@ export * from "./authz";
 export * from "./users";
 export * from "./spaces";
 export * from "./connections";
+export * from "./runs";
 export * from "./connector-sync";
 export * from "./index-jobs";
 export * from "./index-jobs-local";

--- a/packages/store/src/runs.test.ts
+++ b/packages/store/src/runs.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createLibsqlDb } from "./db-libsql";
+import { MIGRATIONS, runMigrations } from "./schema";
+import { ensureConnection, failIndexRun, finishIndexRun, startIndexRun } from "./connections";
+import { failRun, finishRun, latestRun, listRuns, startRun } from "./runs";
+import type { Db } from "./db";
+
+let db: Db;
+const key = { pluginId: "synology", jobName: "connector-index", instanceKey: "connector:synology:maya" };
+
+beforeEach(async () => {
+  db = createLibsqlDb(":memory:");
+  await runMigrations(db);
+});
+
+describe("runs", () => {
+  it("hands the cursor from the last done run to the next start", async () => {
+    const first = await startRun(db, key);
+    expect(first.cursor).toBeNull();
+    await finishRun(db, first.id, { cursor: "1700000000" });
+
+    const second = await startRun(db, key);
+    expect(second.cursor).toBe("1700000000");
+    expect(second.id).not.toBe(first.id);
+  });
+
+  it("does not return a failed run's cursor (next run retries the same range)", async () => {
+    const first = await startRun(db, key);
+    await finishRun(db, first.id, { cursor: "100" });
+    const second = await startRun(db, key);
+    await failRun(db, second.id, "boom");
+
+    // The failed run's row keeps the seeded cursor, but the *handed* cursor is
+    // still the last successful one.
+    const third = await startRun(db, key);
+    expect(third.cursor).toBe("100");
+    const last = await latestRun(db, key);
+    expect(last?.id).toBe(third.id);
+    expect(last?.status).toBe("running");
+  });
+
+  it("round-trips stats as JSON and truncates long errors", async () => {
+    const run = await startRun(db, key);
+    await finishRun(db, run.id, { cursor: null, stats: { filesSeen: 42, folders: ["a", "b"] } });
+    const done = await latestRun(db, key);
+    expect(done?.stats).toEqual({ filesSeen: 42, folders: ["a", "b"] });
+
+    const failed = await startRun(db, key);
+    await failRun(db, failed.id, "x".repeat(600));
+    const err = await latestRun(db, key);
+    expect(err?.error).toHaveLength(500);
+    expect(err?.finishedAt).not.toBeNull();
+  });
+
+  it("allows two concurrent runs for one key — coalescing is the dispatcher's job, not the table's", async () => {
+    const [a, b] = await Promise.all([startRun(db, key), startRun(db, key)]);
+    expect(a.id).not.toBe(b.id);
+    const rows = await listRuns(db, { ...key, status: "running" });
+    expect(rows).toHaveLength(2);
+  });
+
+  it("keys cursors independently per (pluginId, jobName, instanceKey)", async () => {
+    const other = { ...key, instanceKey: "connector:synology:daniel" };
+    const run = await startRun(db, key);
+    await finishRun(db, run.id, { cursor: "555" });
+
+    expect((await startRun(db, other)).cursor).toBeNull();
+    expect((await startRun(db, { ...key, jobName: "connector-sweep" })).cursor).toBeNull();
+    expect((await startRun(db, key)).cursor).toBe("555");
+  });
+
+  it("lists newest-first with filters and a limit", async () => {
+    for (let i = 0; i < 3; i++) {
+      const r = await startRun(db, key);
+      await finishRun(db, r.id, { cursor: String(i) });
+    }
+    const all = await listRuns(db, { pluginId: "synology" });
+    expect(all).toHaveLength(3);
+    expect(all[0]!.cursor).toBe("2"); // newest first
+    expect(await listRuns(db, { pluginId: "synology", limit: 1 })).toHaveLength(1);
+    expect(await listRuns(db, { pluginId: "github" })).toHaveLength(0);
+  });
+});
+
+describe("index-run wrappers (compatibility until T6)", () => {
+  it("keeps startIndexRun/finishIndexRun semantics — cursor handoff + filesSeen in stats", async () => {
+    await ensureConnection(db, {
+      id: "connector:synology:maya",
+      tenantId: "connector:synology:maya",
+      ownerId: "maya",
+      type: "synology",
+      name: "NAS",
+    });
+    const run = await startIndexRun(db, "connector:synology:maya");
+    expect(run.cursor).toBeNull();
+    await finishIndexRun(db, run.id, { cursor: "1700000123", filesSeen: 7 });
+
+    const next = await startIndexRun(db, "connector:synology:maya");
+    expect(next.cursor).toBe("1700000123");
+    // The wrapper keys the run by the connection's type, so runs.ts consumers see it.
+    const row = await latestRun(db, key);
+    expect(row?.status).toBe("running");
+    const done = await listRuns(db, { ...key, status: "done" });
+    expect(done[0]!.stats).toEqual({ filesSeen: 7 });
+  });
+
+  it("failIndexRun leaves the cursor un-advanced", async () => {
+    await ensureConnection(db, {
+      id: "connector:synology:maya",
+      tenantId: "connector:synology:maya",
+      ownerId: "maya",
+      type: "synology",
+      name: "NAS",
+    });
+    const run = await startIndexRun(db, "connector:synology:maya");
+    await failIndexRun(db, run.id, "list failed (401)");
+    const next = await startIndexRun(db, "connector:synology:maya");
+    expect(next.cursor).toBeNull();
+  });
+});
+
+describe("migration 24 (index_runs → runs)", () => {
+  /** Apply migrations up to (not including) `version`, mirroring runMigrations. */
+  async function migrateBelow(target: number, d: Db): Promise<void> {
+    await d.run("CREATE TABLE IF NOT EXISTS _migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)");
+    const now = new Date().toISOString();
+    for (const m of MIGRATIONS.filter((m) => m.version < target)) {
+      await d.batch([
+        ...m.statements.map((sql) => ({ sql })),
+        { sql: "INSERT INTO _migrations (version, applied_at) VALUES (?, ?)", params: [m.version, now] },
+      ]);
+    }
+  }
+
+  it("copies rows across so the crawl cursor survives (incremental, not full, after upgrade)", async () => {
+    const old = createLibsqlDb(":memory:");
+    await migrateBelow(24, old);
+    await ensureConnection(old, {
+      id: "connector:synology:maya",
+      tenantId: "connector:synology:maya",
+      ownerId: "maya",
+      type: "synology",
+      name: "NAS",
+    });
+    await old.run(
+      `INSERT INTO index_runs (id, connection_id, status, cursor, files_seen, started_at, finished_at)
+       VALUES ('r1', 'connector:synology:maya', 'done', '1699999999', 12, '2026-07-01T00:00:00Z', '2026-07-01T00:05:00Z')`,
+    );
+    // An orphaned run (its connection row is gone) must still copy, with plugin_id ''.
+    // FK enforcement would block seeding the orphan directly, so lift it for the insert.
+    await old.run("PRAGMA foreign_keys = OFF");
+    await old.run(
+      `INSERT INTO index_runs (id, connection_id, status, cursor, files_seen, started_at, finished_at)
+       VALUES ('r2', 'connector:gone:x', 'done', '42', 1, '2026-07-01T00:00:00Z', '2026-07-01T00:01:00Z')`,
+    );
+    await old.run("PRAGMA foreign_keys = ON");
+
+    await runMigrations(old); // applies 24: copy + drop
+
+    // Cursor continuity through the wrapper — the next sweep starts incremental.
+    const next = await startIndexRun(old, "connector:synology:maya");
+    expect(next.cursor).toBe("1699999999");
+    const copied = await listRuns(old, { pluginId: "synology", jobName: "connector-index", status: "done" });
+    expect(copied).toHaveLength(1);
+    expect(copied[0]!.stats).toEqual({ filesSeen: 12 });
+
+    // Orphan resolves the same way the wrapper does for a missing connection ('').
+    const orphan = await startIndexRun(old, "connector:gone:x");
+    expect(orphan.cursor).toBe("42");
+
+    // The old table is gone.
+    await expect(old.first("SELECT 1 FROM index_runs LIMIT 1")).rejects.toThrow();
+  });
+});

--- a/packages/store/src/runs.ts
+++ b/packages/store/src/runs.ts
@@ -1,0 +1,157 @@
+import type { Db } from "./db";
+
+/**
+ * Background-job run bookkeeping (jobs rail, T1) — the generalization of the old
+ * `index_runs` table. Every job on the rail needs the same triple: a status row,
+ * a resume cursor handed from the last successful run to the next, and a JSON
+ * counter bag. A run is keyed by (pluginId, jobName, instanceKey) — for the
+ * connector crawl that's (connection type, 'connector-index', connection id).
+ *
+ * Concurrency is deliberately NOT enforced here: two concurrent `startRun` calls
+ * for one key produce two rows. Coalescing ("one in-flight run per key") is the
+ * dispatcher's contract (T2/T3) — a table-level constraint would block
+ * legitimate re-runs after a crash.
+ */
+
+export type RunStatus = "queued" | "running" | "done" | "error";
+
+/** What identifies a job's run history: which handler, for which instance. */
+export interface RunKey {
+  pluginId: string;
+  jobName: string;
+  instanceKey: string;
+}
+
+export interface Run {
+  id: string;
+  pluginId: string;
+  jobName: string;
+  instanceKey: string;
+  status: RunStatus;
+  cursor: string | null;
+  /** JSON counter bag, e.g. `{ filesSeen: 42 }`. Shape is the job's own. */
+  stats: Record<string, unknown>;
+  startedAt: string;
+  finishedAt: string | null;
+  error: string | null;
+}
+
+interface RunRow {
+  id: string;
+  plugin_id: string;
+  job_name: string;
+  instance_key: string;
+  status: RunStatus;
+  cursor: string | null;
+  stats: string;
+  started_at: string;
+  finished_at: string | null;
+  error: string | null;
+}
+
+const toRun = (r: RunRow): Run => {
+  let stats: Record<string, unknown> = {};
+  try {
+    const v = JSON.parse(r.stats);
+    if (v && typeof v === "object") stats = v as Record<string, unknown>;
+  } catch {
+    /* keep {} */
+  }
+  return {
+    id: r.id,
+    pluginId: r.plugin_id,
+    jobName: r.job_name,
+    instanceKey: r.instance_key,
+    status: r.status,
+    cursor: r.cursor,
+    stats,
+    startedAt: r.started_at,
+    finishedAt: r.finished_at,
+    error: r.error,
+  };
+};
+
+/**
+ * Start a run: record a 'running' row seeded with the key's last *successful*
+ * cursor (a failed run never advances the cursor, so the next run retries the
+ * same range). Returns the run id + that cursor.
+ */
+export async function startRun(db: Db, key: RunKey): Promise<{ id: string; cursor: string | null }> {
+  const last = await db.first<{ cursor: string | null }>(
+    `SELECT cursor FROM runs
+      WHERE plugin_id = ? AND job_name = ? AND instance_key = ? AND status = 'done'
+      ORDER BY finished_at DESC, rowid DESC LIMIT 1`,
+    [key.pluginId, key.jobName, key.instanceKey],
+  );
+  const id = crypto.randomUUID();
+  await db.run(
+    `INSERT INTO runs (id, plugin_id, job_name, instance_key, status, cursor, stats, started_at)
+     VALUES (?, ?, ?, ?, 'running', ?, '{}', ?)`,
+    [id, key.pluginId, key.jobName, key.instanceKey, last?.cursor ?? null, new Date().toISOString()],
+  );
+  return { id, cursor: last?.cursor ?? null };
+}
+
+/** Mark a run done, persisting its new cursor + stats. */
+export async function finishRun(
+  db: Db,
+  runId: string,
+  out: { cursor: string | null; stats?: Record<string, unknown> },
+): Promise<void> {
+  await db.run("UPDATE runs SET status = 'done', cursor = ?, stats = ?, finished_at = ? WHERE id = ?", [
+    out.cursor,
+    JSON.stringify(out.stats ?? {}),
+    new Date().toISOString(),
+    runId,
+  ]);
+}
+
+/** Mark a run failed. Its cursor is not advanced, so the next run retries the same range. */
+export async function failRun(db: Db, runId: string, error: string): Promise<void> {
+  await db.run("UPDATE runs SET status = 'error', error = ?, finished_at = ? WHERE id = ?", [
+    String(error ?? "").slice(0, 500),
+    new Date().toISOString(),
+    runId,
+  ]);
+}
+
+/** The most recent run for a key (any status), or null. */
+export async function latestRun(db: Db, key: RunKey): Promise<Run | null> {
+  const row = await db.first<RunRow>(
+    `SELECT * FROM runs WHERE plugin_id = ? AND job_name = ? AND instance_key = ?
+      ORDER BY started_at DESC, rowid DESC LIMIT 1`,
+    [key.pluginId, key.jobName, key.instanceKey],
+  );
+  return row ? toRun(row) : null;
+}
+
+/** Run history, newest first. Every filter is optional; `limit` defaults to 50. */
+export async function listRuns(
+  db: Db,
+  filter: { pluginId?: string; jobName?: string; instanceKey?: string; status?: RunStatus; limit?: number } = {},
+): Promise<Run[]> {
+  const where: string[] = [];
+  const params: unknown[] = [];
+  if (filter.pluginId !== undefined) {
+    where.push("plugin_id = ?");
+    params.push(filter.pluginId);
+  }
+  if (filter.jobName !== undefined) {
+    where.push("job_name = ?");
+    params.push(filter.jobName);
+  }
+  if (filter.instanceKey !== undefined) {
+    where.push("instance_key = ?");
+    params.push(filter.instanceKey);
+  }
+  if (filter.status !== undefined) {
+    where.push("status = ?");
+    params.push(filter.status);
+  }
+  params.push(Math.max(1, Math.min(filter.limit ?? 50, 500)));
+  const rows = await db.all<RunRow>(
+    `SELECT * FROM runs ${where.length ? `WHERE ${where.join(" AND ")}` : ""} ORDER BY started_at DESC, rowid DESC LIMIT ?`,
+    params,
+  );
+  return rows.map(toRun);
+}

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -581,6 +581,41 @@ export const MIGRATIONS: { version: number; statements: string[] }[] = [
        )`,
     ],
   },
+  {
+    // Background-job runs (jobs rail, T1). `index_runs` generalized: every job on
+    // the rail needs the same triple — a status row, a resume cursor handed from
+    // the last successful run to the next, and counters — not just connector
+    // indexing. A run is keyed by (plugin_id, job_name, instance_key); for the
+    // connector crawl that's (connections.type, 'connector-index', connection_id).
+    // `stats` is a JSON counter bag (replaces the single-purpose `files_seen`).
+    // The table does NOT enforce one running row per key — coalescing is the
+    // dispatcher's contract (T2/T3), and a unique constraint here would block
+    // legitimate re-runs after a crash. Existing `index_runs` rows are copied
+    // across (LEFT JOIN: an orphaned run keeps '' as plugin_id, matching what the
+    // wrapper resolves for a missing connection) so the crawl cursor survives —
+    // the first post-migration sweep stays incremental instead of a full crawl.
+    version: 24,
+    statements: [
+      `CREATE TABLE IF NOT EXISTS runs (
+         id           TEXT PRIMARY KEY,
+         plugin_id    TEXT NOT NULL,
+         job_name     TEXT NOT NULL,
+         instance_key TEXT NOT NULL,
+         status       TEXT NOT NULL,              -- 'queued' | 'running' | 'done' | 'error'
+         cursor       TEXT,
+         stats        TEXT NOT NULL DEFAULT '{}', -- JSON counters (e.g. {"filesSeen": 42})
+         started_at   TEXT NOT NULL,
+         finished_at  TEXT,
+         error        TEXT
+       )`,
+      `CREATE INDEX IF NOT EXISTS idx_runs_key ON runs (plugin_id, job_name, instance_key, started_at)`,
+      `INSERT INTO runs (id, plugin_id, job_name, instance_key, status, cursor, stats, started_at, finished_at, error)
+         SELECT r.id, COALESCE(c.type, ''), 'connector-index', r.connection_id, r.status, r.cursor,
+                json_object('filesSeen', r.files_seen), r.started_at, r.finished_at, r.error
+           FROM index_runs r LEFT JOIN connections c ON c.id = r.connection_id`,
+      `DROP TABLE index_runs`,
+    ],
+  },
 ];
 
 /** Apply any migrations newer than what's recorded. Safe to call on every boot. */


### PR DESCRIPTION
T1 of the jobs-rail plan (`documentation/planning/jobs-and-sync-tickets.md`): run tracking stops being connector-specific so the generic `Jobs` rail (T2+) has a table to stand on. Connector indexing simply becomes the first consumer.

## What's included

- **Migration 24**: new `runs` table keyed `(plugin_id, job_name, instance_key)` with `status`, `cursor`, `stats` (JSON counter bag, replaces `files_seen`), timestamps, `error`. Existing `index_runs` rows are copied across (`plugin_id` = `connections.type` via LEFT JOIN — orphaned rows keep `''`, matching what the wrapper resolves for a missing connection), then `index_runs` is dropped. The crawl cursor survives, so the first post-upgrade sweep stays incremental.
- **`packages/store/src/runs.ts`**: `startRun` (returns `{id, cursor}` seeded from the last **done** run — a failed run never advances the cursor), `finishRun`, `failRun`, `latestRun`, `listRuns`. The table does **not** enforce one running row per key — coalescing is the dispatcher's contract (T2/T3), per the ticket's negative criterion.
- **Compatibility wrappers**: `startIndexRun`/`finishIndexRun`/`failIndexRun` now delegate to runs.ts, so `connector-sync.ts`, `index-jobs-local.ts`, the CF workflow, and `connectorIndexStatus` (raw queries updated) behave exactly as before. Deleted in T6.
- **`IndexLog` → `RunLog`** rename in `worker.ts` (same signature; deprecated alias kept until T6).

## Acceptance criteria → verification

- ✅ cursor handoff: `startRun` returns the most recent **done** cursor; a failed run's cursor is not returned (tests)
- ✅ two concurrent `startRun` calls for one key produce two rows (test)
- ✅ stats round-trip + error truncation (tests)
- ✅ migration copy incl. orphaned connection rows; cursor continuity through the wrapper (test)
- ✅ existing behavior unchanged: full store suite passes — 174 tests (9 new), `connector-sync` tests updated to seed/read the new table
- ✅ workspace typecheck (18 projects), `wrangler deploy --dry-run` bundles
- ✅ migration smoke-tested against a **copy of the real dev DB**: 369 `index_runs` rows copied faithfully (all `error` — the dev GitHub connector's failing sweeps), `index_runs` dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)