### PR TITLE
feat(store): Jobs port + in-process adapter (jobs rail T2)

### DIFF
--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -16,6 +16,8 @@ export * from "./users";
 export * from "./spaces";
 export * from "./connections";
 export * from "./runs";
+export * from "./jobs";
+export * from "./jobs-local";
 export * from "./connector-sync";
 export * from "./index-jobs";
 export * from "./index-jobs-local";

--- a/packages/store/src/jobs-local.ts
+++ b/packages/store/src/jobs-local.ts
@@ -1,0 +1,104 @@
+import type { Db } from "./db";
+import { failRun, finishRun, startRun } from "./runs";
+import { assertJobPayload, type JobContext, type JobRequest, type Jobs, type JobStepOpts } from "./jobs";
+
+/** The workflow's `reconcile-*` retry policy — the rail-wide default. */
+const DEFAULT_RETRIES = { limit: 3, delayMs: 5_000, backoff: "exponential" as const };
+
+export interface LocalJobsDeps {
+  db: Db;
+  /** Registry lookup, composed in apps/api (T4). */
+  handlers: (pluginId: string, name: string) => ((ctx: JobContext) => Promise<void>) | null;
+  /** `RunLog`-shaped live-line sink (key = space id). Absent on hosts without a channel. */
+  log?: (key: string, message: string, level?: "info" | "error") => Promise<void>;
+  /** Injectable for tests; defaults to setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * In-process {@link Jobs} for Node / self-host (and the Cloudflare fallback when
+ * the dispatcher Workflow isn't bound) — the generalization of
+ * {@link inProcessIndexJobs}. Runs the handler to completion inside the returned
+ * promise (the caller backgrounds it), recording a `runs` row around it:
+ * running → done with the handler's cursor, or → error. `ctx.step` is sequential
+ * execution with the same per-step retry/backoff the CF workflow uses; `ctx.log`
+ * feeds the `RunLog` sink keyed by `logKey ?? instanceKey`.
+ *
+ * Coalescing: an in-memory keyed-promise map — the single-process reality on
+ * Node. A `start` for an in-flight `pluginId:name:instanceKey` returns that
+ * run's promise; a new run for the key is possible the moment it settles.
+ */
+export function inProcessJobs(deps: LocalJobsDeps): Jobs {
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const inflight = new Map<string, Promise<void>>();
+
+  async function execute(req: JobRequest, payload: Record<string, unknown>): Promise<void> {
+    const run = await startRun(deps.db, { pluginId: req.pluginId, jobName: req.name, instanceKey: req.instanceKey });
+    const logKey = req.logKey ?? req.instanceKey;
+    const log = async (message: string, level?: "info" | "error") => {
+      try {
+        await deps.log?.(logKey, message, level);
+      } catch {
+        /* best-effort: a dropped progress line never fails a run */
+      }
+    };
+
+    const handler = deps.handlers(req.pluginId, req.name);
+    if (!handler) {
+      // A runtime condition (stale schedule, uninstalled plugin), not a caller bug:
+      // record it where the dashboard can see it instead of throwing into a
+      // fire-and-forget caller.
+      await failRun(deps.db, run.id, `no job handler registered for ${req.pluginId}:${req.name}`);
+      return;
+    }
+
+    let nextCursor = run.cursor; // unset by the handler → carried forward
+    const ctx: JobContext = {
+      payload,
+      cursor: run.cursor,
+      setCursor: (next) => {
+        nextCursor = next;
+      },
+      async step<T>(name: string, fn: () => Promise<T>, opts?: JobStepOpts): Promise<T> {
+        const retries = opts?.retries ?? DEFAULT_RETRIES;
+        let attempt = 0;
+        // limit counts retries after the first attempt (CF semantics).
+        for (;;) {
+          try {
+            return await fn();
+          } catch (err) {
+            attempt++;
+            if (attempt > retries.limit) throw err;
+            const factor = (retries.backoff ?? "exponential") === "exponential" ? 2 ** (attempt - 1) : 1;
+            await sleep(retries.delayMs * factor);
+          }
+        }
+      },
+      log,
+    };
+
+    try {
+      await handler(ctx);
+      await finishRun(deps.db, run.id, { cursor: nextCursor });
+    } catch (err) {
+      await failRun(deps.db, run.id, (err as Error).message);
+      throw err;
+    }
+  }
+
+  return {
+    start(req: JobRequest): Promise<void> {
+      const key = `${req.pluginId}:${req.name}:${req.instanceKey}`;
+      const existing = inflight.get(key);
+      if (existing) return existing;
+      // Validate + round-trip BEFORE anything runs: a payload that wouldn't
+      // survive a real queue message is a caller bug and fails loudly, not a
+      // run recorded as error.
+      assertJobPayload(req.payload);
+      const payload = JSON.parse(JSON.stringify(req.payload)) as Record<string, unknown>;
+      const p = execute(req, payload).finally(() => inflight.delete(key));
+      inflight.set(key, p);
+      return p;
+    },
+  };
+}

--- a/packages/store/src/jobs-local.ts
+++ b/packages/store/src/jobs-local.ts
@@ -43,15 +43,6 @@ export function inProcessJobs(deps: LocalJobsDeps): Jobs {
       }
     };
 
-    const handler = deps.handlers(req.pluginId, req.name);
-    if (!handler) {
-      // A runtime condition (stale schedule, uninstalled plugin), not a caller bug:
-      // record it where the dashboard can see it instead of throwing into a
-      // fire-and-forget caller.
-      await failRun(deps.db, run.id, `no job handler registered for ${req.pluginId}:${req.name}`);
-      return;
-    }
-
     let nextCursor = run.cursor; // unset by the handler → carried forward
     const ctx: JobContext = {
       payload,
@@ -77,12 +68,19 @@ export function inProcessJobs(deps: LocalJobsDeps): Jobs {
       log,
     };
 
+    // Failures are runtime conditions (stale schedule, uninstalled plugin, a
+    // backend down), not caller bugs: they're recorded on the run — where the
+    // dashboard and the next scheduled attempt can see them — and NEVER thrown
+    // into the fire-and-forget caller. This also matches the CF adapter, whose
+    // `start` resolves at dispatch: completion is read from `runs`, not the promise.
     try {
+      const handler = deps.handlers(req.pluginId, req.name);
+      if (!handler) throw new Error(`no job handler registered for ${req.pluginId}:${req.name}`);
       await handler(ctx);
       await finishRun(deps.db, run.id, { cursor: nextCursor });
     } catch (err) {
       await failRun(deps.db, run.id, (err as Error).message);
-      throw err;
+      await log(`Error: ${(err as Error).message}`, "error");
     }
   }
 

--- a/packages/store/src/jobs.test.ts
+++ b/packages/store/src/jobs.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createLibsqlDb } from "./db-libsql";
+import { runMigrations } from "./schema";
+import { latestRun, listRuns } from "./runs";
+import { assertJobPayload, type JobContext, type JobHandler } from "./jobs";
+import { inProcessJobs, type LocalJobsDeps } from "./jobs-local";
+import type { Db } from "./db";
+
+let db: Db;
+const registry = new Map<string, JobHandler>();
+const handlers: LocalJobsDeps["handlers"] = (pluginId, name) => registry.get(`${pluginId}:${name}`) ?? null;
+/** Instant sleep that records the delays the adapter asked for. */
+let slept: number[];
+const sleep = (ms: number) => {
+  slept.push(ms);
+  return Promise.resolve();
+};
+const jobs = () => inProcessJobs({ db, handlers, sleep });
+const key = { pluginId: "sync", jobName: "run-flow", instanceKey: "flow-1" };
+const req = { pluginId: "sync", name: "run-flow", instanceKey: "flow-1", payload: {} };
+
+beforeEach(async () => {
+  db = createLibsqlDb(":memory:");
+  await runMigrations(db);
+  registry.clear();
+  slept = [];
+});
+
+describe("in-process Jobs adapter", () => {
+  it("runs a three-step handler to completion; the runs row goes running → done with the handler's cursor", async () => {
+    const order: string[] = [];
+    registry.set("sync:run-flow", async (ctx) => {
+      expect(ctx.cursor).toBeNull(); // first run — nothing to resume from
+      await ctx.step("list-0", async () => order.push("list-0"));
+      await ctx.step("ingest-a", async () => order.push("ingest-a"));
+      await ctx.step("deliver-a", async () => order.push("deliver-a"));
+      ctx.setCursor("2026-07-12T00:00:00Z");
+    });
+    await jobs().start(req);
+    expect(order).toEqual(["list-0", "ingest-a", "deliver-a"]);
+    const run = await latestRun(db, key);
+    expect(run?.status).toBe("done");
+    expect(run?.cursor).toBe("2026-07-12T00:00:00Z");
+  });
+
+  it("hands the cursor to the next run; a handler that never sets one carries it forward", async () => {
+    const seen: (string | null)[] = [];
+    registry.set("sync:run-flow", async (ctx) => {
+      seen.push(ctx.cursor);
+      if (ctx.cursor === null) ctx.setCursor("100"); // only the first run advances it
+    });
+    const j = jobs();
+    await j.start(req);
+    await j.start(req);
+    await j.start(req);
+    expect(seen).toEqual([null, "100", "100"]);
+    expect((await latestRun(db, key))?.cursor).toBe("100"); // carried forward, not dropped
+  });
+
+  it("coalesces concurrent starts for one key; different instance keys run concurrently", async () => {
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    registry.set("sync:run-flow", async () => {
+      calls++;
+      await gate;
+    });
+    const j = jobs();
+    const a = j.start(req);
+    const b = j.start(req); // in-flight same key → coalesced
+    const c = j.start({ ...req, instanceKey: "flow-2" }); // different key → own run
+    expect(b).toBe(a);
+    release();
+    await Promise.all([a, b, c]);
+    expect(calls).toBe(2);
+    expect(await listRuns(db, { pluginId: "sync", status: "done" })).toHaveLength(2);
+
+    // The key frees up once settled: a later start runs again.
+    await j.start(req);
+    expect(calls).toBe(3);
+  });
+
+  it("retries a step with exponential backoff, then succeeds", async () => {
+    let attempts = 0;
+    registry.set("sync:run-flow", async (ctx) => {
+      await ctx.step("flaky", async () => {
+        attempts++;
+        if (attempts < 3) throw new Error("transient");
+      });
+    });
+    await jobs().start(req);
+    expect(attempts).toBe(3);
+    expect(slept).toEqual([5_000, 10_000]); // 5s, then doubled
+    expect((await latestRun(db, key))?.status).toBe("done");
+  });
+
+  it("a permanently failing step exhausts retries, records error, and a re-start re-executes from step 1", async () => {
+    const stepOneRuns: number[] = [];
+    let healed = false;
+    registry.set("sync:run-flow", async (ctx) => {
+      await ctx.step("one", async () => stepOneRuns.push(1));
+      await ctx.step(
+        "two",
+        async () => {
+          if (!healed) throw new Error("backend down");
+        },
+        { retries: { limit: 2, delayMs: 10 } },
+      );
+      ctx.setCursor("done-cursor");
+    });
+    const j = jobs();
+    await expect(j.start(req)).rejects.toThrow("backend down");
+    let run = await latestRun(db, key);
+    expect(run?.status).toBe("error");
+    expect(run?.error).toBe("backend down");
+    expect(run?.cursor).toBeNull(); // never advanced
+
+    healed = true;
+    await j.start(req); // steps are idempotent-by-contract — the re-run converges
+    expect(stepOneRuns).toHaveLength(2); // step 1 re-executed (no replay cache in-process)
+    run = await latestRun(db, key);
+    expect(run?.status).toBe("done");
+    expect(run?.cursor).toBe("done-cursor");
+  });
+
+  it("an unknown pluginId:name records an error run with a clear message and does not throw", async () => {
+    await jobs().start({ ...req, name: "nope" });
+    const run = await latestRun(db, { ...key, jobName: "nope" });
+    expect(run?.status).toBe("error");
+    expect(run?.error).toContain("sync:nope");
+  });
+
+  it("rejects payloads that would not survive a queue message (bytes, functions)", async () => {
+    registry.set("sync:run-flow", async () => {});
+    const j = jobs();
+    expect(() => j.start({ ...req, payload: { bytes: new Uint8Array([1, 2]) } })).toThrow(/never bytes/);
+    expect(() => j.start({ ...req, payload: { cb: () => {} } })).toThrow(/not JSON-serializable/);
+    // Nothing was dispatched — no run rows for the key.
+    expect(await listRuns(db, { pluginId: "sync" })).toHaveLength(0);
+  });
+
+  it("hands the handler a JSON round-trip of the payload, not the caller's object graph", async () => {
+    let got: Record<string, unknown> | undefined;
+    registry.set("sync:run-flow", async (ctx) => {
+      got = ctx.payload;
+    });
+    const payload = { ids: ["a", "b"], nested: { n: 1 } };
+    await jobs().start({ ...req, payload });
+    expect(got).toEqual(payload);
+    expect(got).not.toBe(payload); // queue-boundary simulation
+    expect(got!.ids).not.toBe(payload.ids);
+  });
+
+  it("routes ctx.log to the RunLog sink keyed by logKey ?? instanceKey; a throwing sink never fails the run", async () => {
+    const lines: [string, string, string | undefined][] = [];
+    registry.set("sync:run-flow", async (ctx) => {
+      await ctx.log("hello");
+      await ctx.log("bad", "error");
+    });
+    const deps: LocalJobsDeps = {
+      db,
+      handlers,
+      sleep,
+      log: async (k, m, l) => {
+        if (m === "bad") throw new Error("channel down");
+        lines.push([k, m, l]);
+      },
+    };
+    await inProcessJobs(deps).start({ ...req, logKey: "space-9" });
+    expect(lines).toEqual([["space-9", "hello", undefined]]);
+    await inProcessJobs(deps).start({ ...req, instanceKey: "flow-3" });
+    expect(lines[1]![0]).toBe("flow-3"); // falls back to instanceKey
+    expect((await latestRun(db, { ...key, instanceKey: "flow-3" }))?.status).toBe("done");
+  });
+});
+
+describe("assertJobPayload", () => {
+  it("accepts JSON scalars, plain objects, arrays, null", () => {
+    expect(() => assertJobPayload({ a: 1, b: "x", c: [true, null, { d: 2 }] })).not.toThrow();
+  });
+
+  it("rejects bytes, class instances, bigints, undefined, non-finite numbers — with the offending path", () => {
+    expect(() => assertJobPayload({ buf: new ArrayBuffer(4) })).toThrow(/payload\.buf.*never bytes/);
+    expect(() => assertJobPayload({ when: new Date() })).toThrow(/payload\.when.*Date/);
+    expect(() => assertJobPayload({ big: 1n })).toThrow(/payload\.big/);
+    expect(() => assertJobPayload({ list: [undefined] })).toThrow(/payload\.list\[0\]/);
+    expect(() => assertJobPayload({ n: Infinity })).toThrow(/payload\.n/);
+  });
+});

--- a/packages/store/src/jobs.test.ts
+++ b/packages/store/src/jobs.test.ts
@@ -109,7 +109,7 @@ describe("in-process Jobs adapter", () => {
       ctx.setCursor("done-cursor");
     });
     const j = jobs();
-    await expect(j.start(req)).rejects.toThrow("backend down");
+    await j.start(req); // resolves — the failure lives on the run, never in the caller's promise
     let run = await latestRun(db, key);
     expect(run?.status).toBe("error");
     expect(run?.error).toBe("backend down");
@@ -128,6 +128,20 @@ describe("in-process Jobs adapter", () => {
     const run = await latestRun(db, { ...key, jobName: "nope" });
     expect(run?.status).toBe("error");
     expect(run?.error).toContain("sync:nope");
+  });
+
+  it("a throwing handler lookup still lands the run in a terminal state", async () => {
+    const broken = inProcessJobs({
+      db,
+      sleep,
+      handlers: () => {
+        throw new Error("registry exploded");
+      },
+    });
+    await broken.start(req); // no rejection into the caller
+    const run = await latestRun(db, key);
+    expect(run?.status).toBe("error");
+    expect(run?.error).toBe("registry exploded");
   });
 
   it("rejects payloads that would not survive a queue message (bytes, functions)", async () => {
@@ -185,5 +199,14 @@ describe("assertJobPayload", () => {
     expect(() => assertJobPayload({ big: 1n })).toThrow(/payload\.big/);
     expect(() => assertJobPayload({ list: [undefined] })).toThrow(/payload\.list\[0\]/);
     expect(() => assertJobPayload({ n: Infinity })).toThrow(/payload\.n/);
+  });
+
+  it("rejects a circular payload cleanly, but allows shared acyclic references (like JSON.stringify)", () => {
+    const loop: Record<string, unknown> = {};
+    loop.self = loop;
+    expect(() => assertJobPayload(loop)).toThrow(/payload\.self.*circular/);
+
+    const shared = { id: "x" };
+    expect(() => assertJobPayload({ a: shared, b: shared })).not.toThrow();
   });
 });

--- a/packages/store/src/jobs.ts
+++ b/packages/store/src/jobs.ts
@@ -1,0 +1,114 @@
+/**
+ * Background-work port for the jobs rail (T2) — the generalization of
+ * {@link IndexJobs} from one hard-coded crawl to named handlers. Same
+ * declaration style: structural + serializable, zero Cloudflare / `@canopy/core`
+ * types, selected once at composition time like `DocWorker`. On Cloudflare the
+ * adapter is a generic dispatcher Workflow (T3); on Node / self-host it's the
+ * in-process loop in {@link inProcessJobs} (jobs-local.ts). Handler *types* the
+ * plugin side sees (`JobDefinition`, the `jobs` role) live in
+ * `@canopy/core/plugin-roles` (T4) — structurally compatible, joined in apps/api.
+ */
+
+/**
+ * One job dispatch. `payload` carries ids/config only, NEVER bytes — the
+ * queue-message rule from {@link ExtractJob}: a run fetches bytes itself inside
+ * a step. Adapters JSON-round-trip the payload and reject non-plain values
+ * loudly ({@link assertJobPayload}), so a payload that wouldn't survive a real
+ * queue never appears to work in-process.
+ */
+export interface JobRequest {
+  pluginId: string;
+  name: string;
+  /** What this run is "about" (a space id, a flow id, …) — the coalescing key's last part. */
+  instanceKey: string;
+  payload: Record<string, unknown>;
+  /**
+   * Live-log channel key (a space id — see `RunLog`), when it differs from
+   * `instanceKey`. Connector indexing omits it (its instanceKey IS the space id);
+   * a sync flow passes its target space so progress lines reach that channel.
+   */
+  logKey?: string;
+}
+
+/**
+ * The dispatch port. `start` is idempotent per `pluginId:name:instanceKey`
+ * while a run for that key is in flight — the coalescing contract, enforced by
+ * the adapter (keyed promises in-process, deterministic Workflow instance ids
+ * on CF), never by the `runs` table. Resolution timing is adapter-specific
+ * (in-process: the run itself; CF: dispatch accepted) — callers background it
+ * (`waitUntil` / fire-and-forget) and must not read completion from it.
+ */
+export interface Jobs {
+  start(req: JobRequest): Promise<void>;
+}
+
+/**
+ * Per-step retry policy, structurally mirroring a CF Workflow's `step.do`
+ * config so the T3 adapter maps it 1:1. `limit` counts retries AFTER the first
+ * attempt (limit 3 → up to 4 attempts). Defaults match the existing workflow's
+ * `reconcile-*` steps: 3 retries, 5s delay, exponential backoff.
+ */
+export interface JobStepOpts {
+  retries?: { limit: number; delayMs: number; backoff?: "constant" | "exponential" };
+}
+
+/**
+ * What a handler runs against. `step` is the durability seam: on CF each step
+ * is one `step.do` (own budget, cached on replay), in-process it's sequential
+ * execution with the same retry policy. DETERMINISM CONTRACT: step names must
+ * be a pure function of the payload + prior step results (the `reconcile-<n>`
+ * pattern) — never of wall-clock, randomness, or out-of-band state — so a
+ * crash-resume replays the same name sequence. Step results must be
+ * JSON-serializable (they're the replay cache on CF).
+ */
+export interface JobContext {
+  payload: Record<string, unknown>;
+  /** The last successful run's cursor for this key (high-water mark), or null. */
+  cursor: string | null;
+  /**
+   * Set the cursor the run persists on success. Unset, the previous cursor is
+   * carried forward; a failed run never advances it (runs.ts contract).
+   */
+  setCursor(next: string | null): void;
+  step<T>(name: string, fn: () => Promise<T>, opts?: JobStepOpts): Promise<T>;
+  /** One live progress line to the run's channel (best-effort, never persisted). */
+  log(message: string, level?: "info" | "error"): Promise<void>;
+}
+
+export type JobHandler = (ctx: JobContext) => Promise<void>;
+
+/**
+ * Registry lookup the adapters take as a dependency. The registry itself is
+ * composed in apps/api from the `jobs` server-plugin role (T4) — the store
+ * never knows what's registered.
+ */
+export type JobHandlers = (pluginId: string, name: string) => JobHandler | null;
+
+/**
+ * Reject a payload that wouldn't survive a queue message: only JSON scalars,
+ * plain objects, and arrays. Raw bytes (TypedArray/ArrayBuffer), functions,
+ * class instances (Date, Map, …), bigints, symbols, undefined, and non-finite
+ * numbers all throw with the offending path — ids, never bytes.
+ */
+export function assertJobPayload(value: unknown, path = "payload"): void {
+  if (value === null) return;
+  const t = typeof value;
+  if (t === "string" || t === "boolean") return;
+  if (t === "number") {
+    if (!Number.isFinite(value as number)) throw new Error(`${path} is not JSON-serializable (non-finite number)`);
+    return;
+  }
+  if (t !== "object") throw new Error(`${path} is not JSON-serializable (${t})`);
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+    throw new Error(`${path} contains raw bytes — job payloads carry ids/config only, never bytes`);
+  }
+  if (Array.isArray(value)) {
+    value.forEach((v, i) => assertJobPayload(v, `${path}[${i}]`));
+    return;
+  }
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) {
+    throw new Error(`${path} is not a plain JSON object (got ${value?.constructor?.name ?? "unknown"})`);
+  }
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) assertJobPayload(v, `${path}.${k}`);
+}

--- a/packages/store/src/jobs.ts
+++ b/packages/store/src/jobs.ts
@@ -90,7 +90,7 @@ export type JobHandlers = (pluginId: string, name: string) => JobHandler | null;
  * class instances (Date, Map, …), bigints, symbols, undefined, and non-finite
  * numbers all throw with the offending path — ids, never bytes.
  */
-export function assertJobPayload(value: unknown, path = "payload"): void {
+export function assertJobPayload(value: unknown, path = "payload", ancestors = new WeakSet<object>()): void {
   if (value === null) return;
   const t = typeof value;
   if (t === "string" || t === "boolean") return;
@@ -102,13 +102,22 @@ export function assertJobPayload(value: unknown, path = "payload"): void {
   if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
     throw new Error(`${path} contains raw bytes — job payloads carry ids/config only, never bytes`);
   }
-  if (Array.isArray(value)) {
-    value.forEach((v, i) => assertJobPayload(v, `${path}[${i}]`));
-    return;
+  // Track the ancestor chain only (removed on the way out): a true cycle throws
+  // cleanly with its path, while a shared-but-acyclic reference stays legal —
+  // JSON.stringify duplicates those, it doesn't reject them.
+  if (ancestors.has(value as object)) throw new Error(`${path} contains a circular reference`);
+  ancestors.add(value as object);
+  try {
+    if (Array.isArray(value)) {
+      value.forEach((v, i) => assertJobPayload(v, `${path}[${i}]`, ancestors));
+      return;
+    }
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== Object.prototype && proto !== null) {
+      throw new Error(`${path} is not a plain JSON object (got ${value?.constructor?.name ?? "unknown"})`);
+    }
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) assertJobPayload(v, `${path}.${k}`, ancestors);
+  } finally {
+    ancestors.delete(value as object);
   }
-  const proto = Object.getPrototypeOf(value);
-  if (proto !== Object.prototype && proto !== null) {
-    throw new Error(`${path} is not a plain JSON object (got ${value?.constructor?.name ?? "unknown"})`);
-  }
-  for (const [k, v] of Object.entries(value as Record<string, unknown>)) assertJobPayload(v, `${path}.${k}`);
 }


### PR DESCRIPTION
T2 of the jobs-rail plan (`documentation/planning/jobs-and-sync-tickets.md`), on top of the merged T1 `runs` table (#39). The single-purpose `IndexJobs` port generalizes into a named-handler dispatch rail; connector indexing migrates onto it in T6 (both paths coexist until then).

## What's included

- **`packages/store/src/jobs.ts`** — the port, same declaration style as `IndexJobs`/`DocWorker` (structural, serializable, no CF types):
  - `JobRequest { pluginId, name, instanceKey, payload, logKey? }` — payload is ids/config only, never bytes; `logKey` routes live lines when the run's channel isn't its `instanceKey` (a sync flow's target space).
  - `Jobs.start` — idempotent per `pluginId:name:instanceKey` while in flight (the coalescing contract, adapter-enforced; the `runs` table deliberately doesn't).
  - `JobContext { payload, cursor, setCursor, step(name, fn, opts?), log }` — `step` documents the determinism contract (names are a pure function of payload + prior step results, the `reconcile-<n>` pattern); `JobStepOpts` structurally mirrors CF's `step.do` retry config so T3 maps it 1:1.
  - `JobHandlers` registry lookup — contents composed in apps/api via the `jobs` role (T4).
  - `assertJobPayload` — rejects bytes/class instances/functions/cycles with the offending path, shared with the T3 adapter.
- **`packages/store/src/jobs-local.ts`** — the in-process adapter mirroring `inProcessIndexJobs`: runs the handler to completion off the response path, wraps it in a `runs` row (running → done with the handler's cursor — unset carries forward, failure never advances), per-step retry/backoff with the workflow's `reconcile-*` defaults (3 retries / 5s / exponential; `sleep` injectable), in-memory keyed-promise coalescing, `ctx.log` → `RunLog` sink.
- **Failure contract**: run failures — including a missing or *throwing* handler lookup — are recorded on the run and logged, never rejected into the fire-and-forget caller (an unhandled rejection would kill the Node process). Completion is read from `runs`, matching the CF adapter's dispatch-time resolution. Invalid payloads, by contrast, throw loudly before anything is dispatched — that's a caller bug, not a runtime condition.

## Acceptance criteria → verification (187 store tests pass, 13 new)

- ✅ three-step handler → run `running → done` with the handler's cursor; cursor handed to the next run, carried forward when unset
- ✅ coalescing: concurrent same-key starts run once (same promise); different `instanceKey` runs concurrently; key frees after settle
- ✅ retry: fails-twice-then-succeeds completes; backoff 5s → 10s asserted via injected sleep
- ✅ replay safety: permanent step-2 failure → run `error`, cursor unmoved; re-start re-executes from step 1 and converges
- ✅ ids-not-bytes: payload JSON round-tripped (handler gets a copy); `Uint8Array`/function/circular payloads fail loudly with their path; shared acyclic refs stay legal
- ✅ unknown `pluginId:name` → run recorded `error` with a clear message, no throw
- ✅ workspace typecheck (18 projects), `wrangler deploy --dry-run`
- ✅ CodeRabbit review: 3 findings (no-rethrow contract, throwing-lookup stranding a run, cycle detection) — all addressed in `9e10d90`; re-verified clean by tests

## Deviations from the ticket (small, documented in code)

- `JobContext.setCursor` — the ticket's acceptance criteria require "the cursor the handler set" but its interface sketch had no setter; this is the minimal mechanism.
- `JobRequest.logKey?` — T1 keys `RunLog` by space id and T8's sync flows log to their *target space's* channel while their `instanceKey` is a flow id; an explicit optional key (defaulting to `instanceKey`) resolves that without magic payload sniffing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)